### PR TITLE
change API version to 1.4.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ m4_define([ev_extra_version], [])
 m4_define([ev_version], [ev_major_version.ev_minor_version.ev_micro_version()ev_extra_version])
 
 # The atril API version
-m4_define([ev_api_version], [2.32])
+m4_define([ev_api_version], [1.4.0])
 
 # Libtool versioning. The backend and view libraries have separate versions.
 # Before making a release, the libtool version should be modified.


### PR DESCRIPTION
This will change API version from old gnome API  2.32 to mate 1.4.0.
In result we have changes in install directories.
old:
%{_libdir}/girepository-1.0/AtrilDocument-2.32.typelib
%{_libdir}/girepository-1.0/AtrilView-2.32.typelib
%{_includedir}/atril/2.32/
%{_libdir}/pkgconfig/atril-view-2.32.pc
%{_libdir}/pkgconfig/atril-document-2.32.pc
%{_datadir}/gir-1.0/AtrilDocument-2.32.gir
%{_datadir}/gir-1.0/AtrilView-2.32.gir

new:
%{_libdir}/girepository-1.0/AtrilDocument-1.4.0.typelib
%{_libdir}/girepository-1.0/AtrilView-1.4.0.typelib
%{_includedir}/atril/1.4.0/
%{_libdir}/pkgconfig/atril-view-1.4.0.pc
%{_libdir}/pkgconfig/atril-document-1.4.0.pc
%{_datadir}/gir-1.0/AtrilDocument-1.4.0.gir
%{_datadir}/gir-1.0/AtrilView-1.4.0.gir
