### PR TITLE
Fix for #47 (Ctrl-A in search field)

### DIFF
--- a/shell/eggfindbar.c
+++ b/shell/eggfindbar.c
@@ -65,7 +65,7 @@ static void egg_find_bar_set_property  (GObject        *object,
                                         GParamSpec     *pspec);
 static void egg_find_bar_show          (GtkWidget *widget);
 static void egg_find_bar_hide          (GtkWidget *widget);
-static void egg_find_bar_grab_focus    (GtkWidget *widget);
+void egg_find_bar_grab_focus    (GtkWidget *widget);
 
 G_DEFINE_TYPE (EggFindBar, egg_find_bar, GTK_TYPE_TOOLBAR);
 
@@ -495,7 +495,7 @@ egg_find_bar_hide (GtkWidget *widget)
   GTK_WIDGET_CLASS (egg_find_bar_parent_class)->hide (widget);
 }
 
-static void
+void
 egg_find_bar_grab_focus (GtkWidget *widget)
 {
   EggFindBar *find_bar = EGG_FIND_BAR (widget);

--- a/shell/eggfindbar.h
+++ b/shell/eggfindbar.h
@@ -75,6 +75,8 @@ void        egg_find_bar_get_current_match_color (EggFindBar *find_bar,
 void        egg_find_bar_set_status_text         (EggFindBar *find_bar,
                                                   const char *text);
 
+void        egg_find_bar_grab_focus               (GtkWidget *widget);
+
 G_END_DECLS
 
 #endif /* __EGG_FIND_BAR_H__ */

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -3651,7 +3651,16 @@ ev_window_cmd_edit_select_all (GtkAction *action, EvWindow *ev_window)
 {
 	g_return_if_fail (EV_IS_WINDOW (ev_window));
 
-	ev_view_select_all (EV_VIEW (ev_window->priv->view));
+	/*
+	 * If the find bar is open, select all applies to
+	 * the find field contents. Otherwise it applies
+	 * to the viewing window's contents.
+	 */
+	if (ev_window->priv->chrome & EV_CHROME_FINDBAR) {
+		egg_find_bar_grab_focus(ev_window->priv->find_bar);
+	} else {
+		ev_view_select_all (EV_VIEW (ev_window->priv->view));
+	}
 }
 
 static void


### PR DESCRIPTION
This is a proposed fix patch for bug "Ctrl-A in search field" (https://github.com/mate-desktop/atril/issues/47)
