### PR TITLE
Implement window expand functionality (#53)

### DIFF
--- a/cut-n-paste/zoom-control/ephy-zoom.c
+++ b/cut-n-paste/zoom-control/ephy-zoom.c
@@ -35,11 +35,13 @@ ephy_zoom_get_zoom_level_index (float level)
 	  return 0;
 	} else if (level == EPHY_ZOOM_FIT_WIDTH) {
 	  return 1;
+	} else if (level == EPHY_ZOOM_EXPAND_WINDOW_TO_FIT) {
+	  return 2;
 	}
 
-	previous = zoom_levels[3].level;
+	previous = zoom_levels[4].level;
 
-	for (i = 4; i < n_zoom_levels; i++)
+	for (i = 5; i < n_zoom_levels; i++)
 	{
 		current = zoom_levels[i].level;
 		mean = sqrt (previous * current);

--- a/cut-n-paste/zoom-control/ephy-zoom.h
+++ b/cut-n-paste/zoom-control/ephy-zoom.h
@@ -34,7 +34,8 @@ G_BEGIN_DECLS
 
 #define EPHY_ZOOM_BEST_FIT  (-3.0)
 #define EPHY_ZOOM_FIT_WIDTH (-4.0)
-#define EPHY_ZOOM_SEPARATOR (-5.0)
+#define EPHY_ZOOM_EXPAND_WINDOW_TO_FIT (-5.0)
+#define EPHY_ZOOM_SEPARATOR (-6.0)
 
 static const
 struct
@@ -47,6 +48,7 @@ zoom_levels[] =
 {
 	{ N_("Best Fit"),       EPHY_ZOOM_BEST_FIT  },
 	{ N_("Fit Page Width"), EPHY_ZOOM_FIT_WIDTH },
+	{ N_("Expand Window To Fit"), EPHY_ZOOM_EXPAND_WINDOW_TO_FIT },
 	{ NULL,                 EPHY_ZOOM_SEPARATOR },
 	{ N_("50%"), 0.5 },
 	{ N_("70%"), 0.7071067811 },

--- a/data/atril-ui.xml
+++ b/data/atril-ui.xml
@@ -47,6 +47,7 @@
       <menuitem name="ViewZoomOutMenu" action="ViewZoomOut"/>
       <menuitem name="ViewBestFitMenu" action="ViewBestFit"/>
       <menuitem name="ViewPageWidthMenu" action="ViewPageWidth"/>
+      <menuitem name="ViewExpandWindowMenu" action="ViewExpandWindow"/>
       <separator/>
       <menuitem name="ViewReload" action="ViewReload"/>
     </menu>


### PR DESCRIPTION
This implements feature request #53, which is to have a button which
expands the window to the current pixel scale size of the current
page. The functionality is accessible through the scale drop-down menu
in the toolbar, and through a menu item in the "view" menu which is also
mapped to the keyboard sequence "control-e", (e for "expand", I guess).

Below are some screenshots of the feature.

![screenshot 1](https://sites.google.com/site/bl0ckeduserssoftware/atril1.png)
![screenshot 2](https://sites.google.com/site/bl0ckeduserssoftware/atril2.png)
![screenshot 3](https://sites.google.com/site/bl0ckeduserssoftware/atril3.png)
