### PR TITLE
GTK3-compatibility fixes.

### DIFF
--- a/libview/ev-timeline.c
+++ b/libview/ev-timeline.c
@@ -150,7 +150,7 @@ ev_timeline_run_frame (EvTimeline *timeline)
 	gdouble         progress;
 	guint           elapsed_time;
 
-	GDK_THREADS_ENTER ();
+	gdk_threads_enter();
 
 	priv = EV_TIMELINE_GET_PRIV (timeline);
 
@@ -174,7 +174,7 @@ ev_timeline_run_frame (EvTimeline *timeline)
 		}
 	}
 
-	GDK_THREADS_LEAVE ();
+	gdk_threads_leave();
 
 	return TRUE;
 }

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -5070,14 +5070,26 @@ zoom_control_changed_cb (EphyZoomAction *action,
 		 * we must account for their sizes in calculating 
 		 * the new expanded window size.
 		 */
+
+
 		if (ev_window->priv->chrome & EV_CHROME_SIDEBAR)
-			new_width += ev_window->priv->sidebar_thumbs->allocation.width;
-
+		{
+			GtkAllocation alloc;
+			gtk_widget_get_allocation(ev_window->priv->sidebar_thumbs, &alloc);
+			new_width += alloc.width;
+		}
 		if (ev_window->priv->chrome & EV_CHROME_TOOLBAR)
-			new_height += GTK_WIDGET(ev_window->priv->toolbar)->allocation.height;
-
+		{
+			GtkAllocation alloc;
+			gtk_widget_get_allocation(GTK_WIDGET(ev_window->priv->toolbar), &alloc);
+			new_height += alloc.height;
+		}
 		if (ev_window->priv->chrome & EV_CHROME_MENUBAR)
-			new_height += GTK_WIDGET(ev_window->priv->menubar)->allocation.height;
+		{
+			GtkAllocation alloc;
+			gtk_widget_get_allocation(GTK_WIDGET(ev_window->priv->menubar), &alloc);
+			new_height += alloc.height;
+		}
 
 		/*
 		 * Add a little slack


### PR DESCRIPTION
Fixes to make atril running on latest GTK+ 3.10
Anyway, it still needs --disable-caja flag, because otherwise, it links against gtk+-x11 which is part of GTK2. It probably could be fixed via autotools change (I'm not autotools expert).
