### PR TITLE
Fix crash when clicking empty canvas while loading.

### DIFF
--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -88,7 +88,7 @@ static gboolean      new_selection_surface_needed(EvPixbufCache      *pixbuf_cac
 #define VISIBLE_NEXT_LEN(pixbuf_cache) \
 	(MIN(pixbuf_cache->preload_cache_size, ev_document_get_n_pages (pixbuf_cache->document) - (1 + pixbuf_cache->end_page)))
 #define PAGE_CACHE_LEN(pixbuf_cache) \
-	((pixbuf_cache->end_page - pixbuf_cache->start_page) + 1)
+	(pixbuf_cache->start_page>=0?((pixbuf_cache->end_page - pixbuf_cache->start_page) + 1):0)
 
 #define MAX_PRELOADED_PAGES 3
 


### PR DESCRIPTION
The PAGE_CACHE_LEN macro erroneously evaluates to 1 in the pixbuf_cache structure's freshly initialised state (start_page, end_page are -1). This causes a segfault (observed idly clicking the canvas while loading a big DJVU file) when `ev_pixbuf_cache_set_selection_list` calls `clear_job_selection(pixbuf_cache->job_list + 0)`.
