### PR TITLE
Can build with epub support disabled

### DIFF
--- a/libview/ev-jobs.c
+++ b/libview/ev-jobs.c
@@ -41,7 +41,7 @@
 #include "ev-debug.h"
 
 #include <gtk/gtk.h>
-#ifdef ENABLE_EPUB
+#if ENABLE_EPUB
 #if GTK_CHECK_VERSION(3, 0, 0)
 #include <webkit2/webkit2.h>
 #else
@@ -790,6 +790,7 @@ ev_job_thumbnail_dispose (GObject *object)
 	(* G_OBJECT_CLASS (ev_job_thumbnail_parent_class)->dispose) (object);
 }
 
+#if ENABLE_EPUB
 #if !GTK_CHECK_VERSION(3, 0, 0)
 static gboolean
 web_thumbnail_get_screenshot_cb(EvJobThumbnail *job_thumb)
@@ -860,7 +861,7 @@ web_thumbnail_get_screenshot_cb (WebKitWebView  *webview,
 	                              g_object_ref(job_thumb));
 }
 #endif
-
+#endif
 static gboolean
 ev_job_thumbnail_run (EvJob *job)
 {
@@ -888,6 +889,7 @@ ev_job_thumbnail_run (EvJob *job)
 	}
 	g_object_unref (page);
 
+#if ENABLE_EPUB
 	if (job->document->iswebdocument == TRUE) {
 		if (!webview) {
 				webview = webkit_web_view_new();
@@ -916,7 +918,9 @@ ev_job_thumbnail_run (EvJob *job)
 
 #endif
 	}
-	else {
+	else 
+#endif
+	{
 		job_thumb->thumbnail = ev_document_thumbnails_get_thumbnail (EV_DOCUMENT_THUMBNAILS (job->document),
 										 rc, TRUE);
 		ev_document_doc_mutex_unlock ();

--- a/libview/ev-web-view.c
+++ b/libview/ev-web-view.c
@@ -17,7 +17,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-
+#if ENABLE_EPUB
 #include "config.h"
 
 #include <glib/gi18n-lib.h>
@@ -871,3 +871,4 @@ ev_web_view_disconnect_handlers(EvWebView *webview)
 	                                     ev_web_view_page_changed_cb,
 	                                     webview);
 }
+#endif

--- a/libview/ev-web-view.h
+++ b/libview/ev-web-view.h
@@ -22,6 +22,8 @@
 #error "Only <atril-web_view.h> can be included directly."
 #endif
 
+#include "config.h"
+#if ENABLE_EPUB
 #ifndef __EV_WEB_VIEW_H__
 #define __EV_WEB_VIEW_H__
 
@@ -87,3 +89,4 @@ void       ev_web_view_disconnect_handlers    (EvWebView  *webview);
 G_END_DECLS
 
 #endif /* __EV_WEB_VIEW_H__ */
+#endif /* ENABLE_EPUB */


### PR DESCRIPTION
Added the required preprocessor directives to make building without epub support possible. Tested with both GTK2 and GTK3.

@infirit please have a look.
