### PR TITLE
add ini file for caja extension

### DIFF
--- a/properties/Makefile.am
+++ b/properties/Makefile.am
@@ -30,6 +30,11 @@ libatril_properties_page_la_LIBADD = 		\
 
 libatril_properties_page_la_LDFLAGS = -module -avoid-version -no-undefined
 
+extensiondir = $(datadir)/caja/extensions
+extension_in_files = libatril-properties-page.caja-extension.in
+extension_DATA = $(extension_in_files:.caja-extension.in=.caja-extension)
+%.caja-extension: %.caja-extension.in $(INTLTOOL_MERGE) $(wildcard $(top_srcdir)/po/*.po) ; $(AM_V_GEN) LC_ALL=C $(INTLTOOL_MERGE) -d -u -c $(top_builddir)/po/.intltool-merge-cache $(top_srcdir)/po $< $@
+
 endif # ENABLE_CAJA
 
 -include $(top_srcdir)/git.mk

--- a/properties/libatril-properties-page.caja-extension.in
+++ b/properties/libatril-properties-page.caja-extension.in
@@ -1,0 +1,4 @@
+[Caja Extension]
+Icon=atril
+Name=Atril properties
+Description=Shows details for Atril documents


### PR DESCRIPTION
This PR adds an .ini file for the optional caja extension included with Atril. 
