### PR TITLE
Create atril.appdata.xml

### DIFF
--- a/data/atril.appdata.xml
+++ b/data/atril.appdata.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 MATE team <mate-dev@ml.mate-desktop.org> -->
+<component type="desktop">
+ <id>atril.desktop</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-2.0+</project_license>
+ <name>Atril Document Viewer</name>
+ <summary>A Document Viewer for the MATE desktop environment</summary>
+ <description>
+  <p>
+   Atril is a simple multi-page document viewer. It can display and
+   print PostScript (PS), Encapsulated PostScript (EPS), DJVU, DVI,
+   XPS and Portable Document Format (PDF) files, as well as comic book
+   archive files. When supported by the document, it also allows
+   searching for text, copying text to the clipboard, hypertext navigation
+   and table-of-contents bookmarks.
+  </p>
+  <p>
+   Atril is a fork of Evince and part of the MATE Desktop Environment.
+   If you would like to know more about MATE and Atril, please visit the
+   project's home page.
+  </p>
+ </description>
+ <screenshots>
+  <screenshot type="default">
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/atril/screens/atril_01.png
+   </image>
+  </screenshot>
+  <screenshot>
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/atril/screens/atril_02.png
+   </image>
+  </screenshot>
+  <screenshot>
+   <image width="960" height="540">
+    https://alexpl.fedorapeople.org/AppData/atril/screens/atril_03.png
+   </image>
+  </screenshot>
+ </screenshots>
+ <url type="homepage">http://www.mate-desktop.org</url>
+ <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
+ <project_group>MATE</project_group>
+</component>


### PR DESCRIPTION
An appdata file for inclusion in the upcoming software centers as per the new freedesktop.org specs.

It should be placed in /usr/share/appdata/ similar to the way .desktop files are placed in /usr/share/applications/, e.g. if you have a "$(datadir)/applications" definition in your makefiles, you need to add a "$(datadir)/appdata" as well.

Please, skim through the file in case I made a mistake and please, include it in the 1.8 branch as well.

Thanks!
