### PR TITLE
libdocument: Fix saving attachments when the name contains a path

### DIFF
--- a/libdocument/ev-attachment.c
+++ b/libdocument/ev-attachment.c
@@ -414,13 +414,16 @@ ev_attachment_open (EvAttachment *attachment,
 		retval = ev_attachment_launch_app (attachment, screen,
 						   timestamp, error);
 	} else {
+                char *basename;
                 char *template;
 		GFile *file;
 
                 /* FIXMEchpe: convert to filename encoding first! */
-                template = g_strdup_printf ("%s.XXXXXX", ev_attachment_get_name (attachment));
+                basename = g_path_get_basename (ev_attachment_get_name (attachment));
+                template = g_strdup_printf ("%s.XXXXXX", basename);
                 file = ev_mkstemp_file (template, error);
                 g_free (template);
+                g_free (basename);
 
 		if (file != NULL && ev_attachment_save (attachment, file, error)) {
 			if (attachment->priv->tmp_file)


### PR DESCRIPTION
Bugfix of Evince bug 679354: Use the basename for the temp file template instead of using the attachment name directly.

https://bugzilla.gnome.org/show_bug.cgi?id=679354

(cherry picked from commit ff8a330756f in Evince)