### PR TITLE
Made the dependancy on mate-desktop optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -199,7 +199,7 @@ case "$with_platform" in
         ;;
 esac
 
-PKG_CHECK_MODULES([SHELL_CORE],[libxml-2.0 >= $LIBXML_REQUIRED gtk+-$GTK_API_VERSION >= $GTK_REQUIRED gio-2.0 >= $GLIB_REQUIRED gthread-2.0 mate-desktop-2.0 >= $MATEDESKTOP_REQUIRED $SHELL_PLATFORM_PKGS])
+PKG_CHECK_MODULES([SHELL_CORE],[libxml-2.0 >= $LIBXML_REQUIRED gtk+-$GTK_API_VERSION >= $GTK_REQUIRED gio-2.0 >= $GLIB_REQUIRED gthread-2.0 $SHELL_PLATFORM_PKGS])
 
 dnl
 dnl zlib support
@@ -754,6 +754,23 @@ AC_SUBST(ATRIL_MIME_TYPES)
 
 AC_CHECK_FUNC(localtime_r, AC_DEFINE(HAVE_LOCALTIME_R, 1, [Defines if localtime_r is available on your system]))
 
+# *********************
+# Mate-desktop support
+# *********************
+
+AC_ARG_WITH(matedesktop,
+        [AS_HELP_STRING([--without-matedesktop],
+                        [Disable the use of matedesktop])],
+        [],
+        [with_matedesktop=yes])
+
+AM_CONDITIONAL([WITH_MATEDESKTOP],[test "$with_matedesktop" = "yes"])
+
+if test "$with_matedesktop" = "yes"; then
+        PKG_CHECK_MODULES([SHELL_CORE], mate-desktop-2.0 >= $MATEDESKTOP_REQUIRED)
+        AC_DEFINE([WITH_MATEDESKTOP],[1],[Define if mate-desktop support is enabled])
+fi
+
 # *****************
 # Help files
 # *****************
@@ -923,27 +940,28 @@ AC_OUTPUT
 echo "
 Configure summary:
 
-    Platform...........:    $with_platform
-    GTK+ version.......:    $with_gtk
-    GTK+ Unix Print....:    $with_gtk_unix_print
-    Keyring Support....:    $with_keyring
-    DBUS Support.......:    $enable_dbus
-    SM client support..:    $with_smclient
-    Caja Plugin........:    $enable_caja
-    Thumbnailer........:    $enable_thumbnailer
-    Previewer..........:    $enable_previewer
-    Gtk-Doc Support....:    $enable_gtk_doc
-    Debug mode.........:    $enable_debug
-    GObj. Introspection:    $enable_introspection
-    Tests..............:    $enable_tests
+    Platform............:    $with_platform
+    GTK+ version........:    $with_gtk
+    GTK+ Unix Print.....:    $with_gtk_unix_print
+    Mate desktop Support:    $with_matedesktop
+    Keyring Support.....:    $with_keyring
+    DBUS Support........:    $enable_dbus
+    SM client support...:    $with_smclient
+    Caja Plugin.........:    $enable_caja
+    Thumbnailer.........:    $enable_thumbnailer
+    Previewer...........:    $enable_previewer
+    Gtk-Doc Support.....:    $enable_gtk_doc
+    Debug mode..........:    $enable_debug
+    GObj. Introspection.:    $enable_introspection
+    Tests...............:    $enable_tests
 
-    PDF Backend........:    $enable_pdf
-    PostScript Backend.:    $enable_ps
-    TIFF Backend.......:    $enable_tiff
-    DJVU Backend.......:    $enable_djvu
-    DVI Backend........:    $enable_dvi
-    Pixbuf Backend.....:    $enable_pixbuf
-    Comics Backend.....:    $enable_comics
-    XPS Backend........:    $enable_xps
-    ePub Backend.......:    $enable_epub
+    PDF Backend.........:    $enable_pdf
+    PostScript Backend..:    $enable_ps
+    TIFF Backend........:    $enable_tiff
+    DJVU Backend........:    $enable_djvu
+    DVI Backend.........:    $enable_dvi
+    Pixbuf Backend......:    $enable_pixbuf
+    Comics Backend......:    $enable_comics
+    XPS Backend.........:    $enable_xps
+    ePub Backend........:    $enable_epub
 "

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -41,8 +41,10 @@
 #include <gio/gio.h>
 #include <gtk/gtk.h>
 
+#ifdef WITH_MATEDESKTOP
 #include <libmate-desktop/mate-aboutdialog.h>
 #include <libmate-desktop/mate-gsettings.h>
+#endif
 
 #include "egg-editable-toolbar.h"
 #include "egg-toolbar-editor.h"
@@ -1501,7 +1503,13 @@ ev_window_setup_document (EvWindow *ev_window)
 				  ev_window);
 	}
 
+#ifdef WITH_MATEDESKTOP
 	if (mate_gsettings_schema_exists (MATE_LOCKDOWN_SCHEMA)) {
+#else
+	GSettingsSchema *schema_mate_lockdown_schema = g_settings_schema_source_lookup (g_settings_schema_source_get_default(), MATE_LOCKDOWN_SCHEMA, FALSE);
+	if (schema_mate_lockdown_schema != NULL) {
+		g_settings_schema_unref (schema_mate_lockdown_schema);
+#endif
 		if (!ev_window->priv->lockdown_settings)
 			ev_window->priv->lockdown_settings = g_settings_new (MATE_LOCKDOWN_SCHEMA);
 		g_signal_connect (ev_window->priv->lockdown_settings,
@@ -5053,7 +5061,11 @@ ev_window_cmd_help_about (GtkAction *action, EvWindow *ev_window)
 
 	comments = build_comments_string (ev_window->priv->document);
 
+#ifdef WITH_MATEDESKTOP
 	mate_show_about_dialog (
+#else
+	gtk_show_about_dialog (
+#endif
 		GTK_WINDOW (ev_window),
 		"name", _("Atril"),
 		"version", VERSION,


### PR DESCRIPTION
Hi,

Since I use XFCE I don't like the fact that mate-desktop is installed on my system just to support Atril. Evince looks out of place on my desktop since CSD so I opted for Atril.

Because Evince didn't require gnome-desktop I guessed that the work involved wouldn't be that much. So rather than complain on the fora I decided to do something about that.

I'd guess this would make Atril more interesting for XFCE users.

Regards,
Geert
