### PR TITLE
require libgxps >= 0.2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -671,7 +671,7 @@ AC_ARG_ENABLE(xps,
 	[enable_xps=yes])
 
 if test "x$enable_xps" = "xyes"; then
-   GXPS_REQUIRED=0.0.1
+   GXPS_REQUIRED=0.2.0
    PKG_CHECK_MODULES(GXPS, libgxps >= $GXPS_REQUIRED,enable_xps=yes,enable_xps=no)
 
    if test "x$enable_xps" = "xyes"; then


### PR DESCRIPTION
code changes from https://github.com/GNOME/evince/commit/740263e84f812e069c25d32e6fbf40bec4c061e2 are already in, but the version bump isn't. fixed that.