### PR TITLE
findbar and command-line options fixes from upstream

### DIFF
--- a/shell/ev-application.c
+++ b/shell/ev-application.c
@@ -254,15 +254,20 @@ ev_spawn (const char     *uri,
 	g_string_append_printf (cmd, " %s", path);
 	g_free (path);
 
-	/* Page label */
+	/* Page label or index */
 	if (dest) {
-		const gchar *page_label;
-
-		page_label = ev_link_dest_get_page_label (dest);
-		if (page_label)
-			g_string_append_printf (cmd, " --page-label=%s", page_label);
-		else
-			g_string_append_printf (cmd, " --page-label=%d", ev_link_dest_get_page (dest));
+		switch (ev_link_dest_get_dest_type (dest)) {
+		case EV_LINK_DEST_TYPE_PAGE_LABEL:
+			g_string_append_printf (cmd, " --page-label=%s",
+			                        ev_link_dest_get_page_label (dest));
+			break;
+		case EV_LINK_DEST_TYPE_PAGE:
+			g_string_append_printf (cmd, " --page-index=%d",
+			                        ev_link_dest_get_page (dest) + 1);
+			break;
+		default:
+			break;
+		}
 	}
 
 	/* Find string */
@@ -440,10 +445,10 @@ on_register_uri_cb (GObject      *source_object,
 	g_variant_get (value, "(&s)", &owner);
 
 	/* This means that the document wasn't already registered; go
-         * ahead with opening it.
-         */
+	 * ahead with opening it.
+	 */
 	if (owner[0] == '\0') {
-                g_variant_unref (value);
+		g_variant_unref (value);
 
 		application->doc_registered = TRUE;
 
@@ -456,38 +461,47 @@ on_register_uri_cb (GObject      *source_object,
 						  data->timestamp);
 		ev_register_doc_data_free (data);
 
-                return;
-        }
+		return;
+	}
 
 	/* Already registered */
 	g_variant_builder_init (&builder, G_VARIANT_TYPE ("(a{sv}u)"));
-        g_variant_builder_open (&builder, G_VARIANT_TYPE ("a{sv}"));
-        g_variant_builder_add (&builder, "{sv}",
-                               "display",
-                               g_variant_new_string (gdk_display_get_name (gdk_screen_get_display (data->screen))));
-        g_variant_builder_add (&builder, "{sv}",
-                               "screen",
-                               g_variant_new_int32 (gdk_screen_get_number (data->screen)));
+	g_variant_builder_open (&builder, G_VARIANT_TYPE ("a{sv}"));
+	g_variant_builder_add (&builder, "{sv}",
+	                       "display",
+	                       g_variant_new_string (gdk_display_get_name (gdk_screen_get_display (data->screen))));
+	g_variant_builder_add (&builder, "{sv}",
+	                       "screen",
+	                       g_variant_new_int32 (gdk_screen_get_number (data->screen)));
 	if (data->dest) {
-                g_variant_builder_add (&builder, "{sv}",
-                                       "page-label",
-                                       g_variant_new_string (ev_link_dest_get_page_label (data->dest)));
+		switch (ev_link_dest_get_dest_type (data->dest)) {
+		case EV_LINK_DEST_TYPE_PAGE_LABEL:
+			g_variant_builder_add (&builder, "{sv}", "page-label",
+			                       g_variant_new_string (ev_link_dest_get_page_label (data->dest)));
+			break;
+		case EV_LINK_DEST_TYPE_PAGE:
+			g_variant_builder_add (&builder, "{sv}", "page-index",
+			                       g_variant_new_uint32 (ev_link_dest_get_page (data->dest)));
+			break;
+		default:
+			break;
+		}
 	}
 	if (data->search_string) {
-                g_variant_builder_add (&builder, "{sv}",
-                                       "find-string",
-                                       g_variant_new_string (data->search_string));
+		g_variant_builder_add (&builder, "{sv}",
+		                       "find-string",
+		                       g_variant_new_string (data->search_string));
 	}
 	if (data->mode != EV_WINDOW_MODE_NORMAL) {
-                g_variant_builder_add (&builder, "{sv}",
-                                       "mode",
-                                       g_variant_new_uint32 (data->mode));
+		g_variant_builder_add (&builder, "{sv}",
+		                       "mode",
+		                       g_variant_new_uint32 (data->mode));
 	}
-        g_variant_builder_close (&builder);
+	g_variant_builder_close (&builder);
 
-        g_variant_builder_add (&builder, "u", data->timestamp);
+	g_variant_builder_add (&builder, "u", data->timestamp);
 
-        g_dbus_connection_call (connection,
+	g_dbus_connection_call (connection,
 				owner,
 				APPLICATION_DBUS_OBJECT_PATH,
 				APPLICATION_DBUS_INTERFACE,
@@ -776,6 +790,8 @@ method_call_cb (GDBusConnection       *connection,
 			mode = g_variant_get_uint32 (value);
 			} else if (strcmp (key, "page-label") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_STRING) {
 				dest = ev_link_dest_new_page_label (g_variant_get_string (value, NULL));
+			} else if (strcmp (key, "page-index") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_UINT32) {
+				dest = ev_link_dest_new_page (g_variant_get_uint32 (value));
 			} else if (strcmp (key, "find-string") == 0 && g_variant_classify (value) == G_VARIANT_CLASS_STRING) {
 				search_string = g_variant_get_string (value, NULL);
 			}

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -1749,7 +1749,8 @@ ev_window_load_job_cb (EvJob *job,
 				break;
 		}
 
-		if (ev_window->priv->search_string && EV_IS_DOCUMENT_FIND (document)) {
+		if (ev_window->priv->search_string && EV_IS_DOCUMENT_FIND (document) &&
+		    ev_window->priv->window_mode != EV_WINDOW_MODE_PRESENTATION) {
 			ev_window_cmd_edit_find (NULL, ev_window);
 			egg_find_bar_set_search_string (EGG_FIND_BAR (ev_window->priv->find_bar),
 							ev_window->priv->search_string);
@@ -2285,7 +2286,8 @@ ev_window_open_document (EvWindow       *ev_window,
 		break;
 	}
 
-	if (search_string && EV_IS_DOCUMENT_FIND (document)) {
+	if (search_string && EV_IS_DOCUMENT_FIND (document) &&
+	    mode != EV_WINDOW_MODE_PRESENTATION) {
 		ev_window_cmd_edit_find (NULL, ev_window);
 		egg_find_bar_set_search_string (EGG_FIND_BAR (ev_window->priv->find_bar),
 						search_string);
@@ -3873,12 +3875,13 @@ ev_window_cmd_edit_select_all (GtkAction *action, EvWindow *ev_window)
 static void
 ev_window_cmd_edit_find (GtkAction *action, EvWindow *ev_window)
 {
-        g_return_if_fail (EV_IS_WINDOW (ev_window));
-
 	if (ev_window->priv->document == NULL || !EV_IS_DOCUMENT_FIND (ev_window->priv->document)) {
 		g_error ("Find action should be insensitive since document doesn't support find");
 		return;
-	} 
+	}
+
+	if (EV_WINDOW_IS_PRESENTATION (ev_window))
+		return;
 
 	update_chrome_flag (ev_window, EV_CHROME_FINDBAR, TRUE);
 	update_chrome_visibility (ev_window);
@@ -3888,7 +3891,8 @@ ev_window_cmd_edit_find (GtkAction *action, EvWindow *ev_window)
 static void
 ev_window_cmd_edit_find_next (GtkAction *action, EvWindow *ev_window)
 {
-        g_return_if_fail (EV_IS_WINDOW (ev_window));
+	if (EV_WINDOW_IS_PRESENTATION (ev_window))
+		return;
 
 	update_chrome_flag (ev_window, EV_CHROME_FINDBAR, TRUE);
 	update_chrome_visibility (ev_window);
@@ -3906,7 +3910,8 @@ ev_window_cmd_edit_find_next (GtkAction *action, EvWindow *ev_window)
 static void
 ev_window_cmd_edit_find_previous (GtkAction *action, EvWindow *ev_window)
 {
-        g_return_if_fail (EV_IS_WINDOW (ev_window));
+	if (EV_WINDOW_IS_PRESENTATION (ev_window))
+		return;
 
 	update_chrome_flag (ev_window, EV_CHROME_FINDBAR, TRUE);
 	update_chrome_visibility (ev_window);

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -1683,7 +1683,7 @@ static void
 ev_window_handle_link (EvWindow *ev_window,
 		       EvLinkDest *dest)
 {
-	if (ev_window->priv->document->iswebdocument == FALSE ) {
+	if (ev_window->priv->document->iswebdocument == TRUE ) {
 		return;
 	}
 	if (dest) {

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -1532,10 +1532,21 @@ ev_window_setup_document (EvWindow *ev_window)
 	
 	info = ev_document_get_info (document);
 	update_document_mode (ev_window, info->mode);
+
+	if (EV_IS_DOCUMENT_FIND (document)) {
+		if (ev_window->priv->search_string &&
+		    !EV_WINDOW_IS_PRESENTATION (ev_window)) {
+			ev_window_cmd_edit_find (NULL, ev_window);
+			egg_find_bar_set_search_string (EGG_FIND_BAR (ev_window->priv->find_bar), ev_window->priv->search_string);
+		}
+
+		g_clear_pointer (&ev_window->priv->search_string, g_free);
+	}
+
 	/*FIXME*/
 	if (EV_WINDOW_IS_PRESENTATION (ev_window) && document->iswebdocument == FALSE)
 		gtk_widget_grab_focus (ev_window->priv->presentation_view);
-	else {
+	else if (!gtk_widget_get_visible (ev_window->priv->find_bar)) {
 		if ( document->iswebdocument == FALSE )
 			gtk_widget_grab_focus (ev_window->priv->view);
 		#if ENABLE_EPUB
@@ -1748,16 +1759,6 @@ ev_window_load_job_cb (EvJob *job,
 		        default:
 				break;
 		}
-
-		if (ev_window->priv->search_string && EV_IS_DOCUMENT_FIND (document) &&
-		    ev_window->priv->window_mode != EV_WINDOW_MODE_PRESENTATION) {
-			ev_window_cmd_edit_find (NULL, ev_window);
-			egg_find_bar_set_search_string (EGG_FIND_BAR (ev_window->priv->find_bar),
-							ev_window->priv->search_string);
-		}
-
-		g_free (ev_window->priv->search_string);
-		ev_window->priv->search_string = NULL;
 
 		/* Create a monitor for the document */
 		ev_window->priv->monitor = ev_file_monitor_new (ev_window->priv->uri);


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/atril/issues/138 (makes ```--page-index```, ```--page-label``` and ```--find``` options work properly).

@infirit @flexiondotorg @NiceandGently 
I'd like to get this fix into 1.10.x, please test for any possible regressions (especially with epubs) :smile: