### PR TITLE
Fix crash for epubs when accessibility is enabled

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -313,6 +313,16 @@ epub_document_links_get_links_model(EvDocumentLinks *document_links)
     return model;
 }
 
+static EvMappingList *
+epub_document_links_get_links (EvDocumentLinks *document_links,
+			       EvPage	       *page)
+{
+	/* TODO
+	 * ev_mapping_list_new()
+	 */
+	return NULL;
+}
+
 static void
 epub_document_document_thumbnails_iface_init (EvDocumentThumbnailsInterface *iface)
 {
@@ -331,6 +341,7 @@ epub_document_document_links_iface_init(EvDocumentLinksInterface *iface)
 {
     iface->has_document_links = epub_document_links_has_document_links;
     iface->get_links_model = epub_document_links_get_links_model;  
+    iface->get_links = epub_document_links_get_links;
 }
 
 static gboolean


### PR DESCRIPTION
Once epub support has been implemented, atril crashes with all epubs.
Backtrace for 1.10.2+repack1-1 (Debian Stretch):

Program received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffd26d2700 (LWP 22276)]
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in  ()
#1  0x00007ffff755914e in ev_job_page_data_run (job=0x9e3850 [EvJobPageData]) at ev-jobs.c:762
#2  0x00007ffff755a85a in ev_job_thread_proxy (job=0x9e3850 [EvJobPageData]) at ev-job-scheduler.c:184
#3  0x00007ffff755a85a in ev_job_thread_proxy (data=<optimized out>) at ev-job-scheduler.c:217
#4  0x00007ffff14e1955 in g_thread_proxy (data=0x7fff84002280) at /build/glib2.0-VKSJTv/glib2.0-2.46.1/./glib/gthread.c:778
#5  0x00007ffff08690a4 in start_thread (arg=0x7fffd26d2700) at pthread_create.c:309
#6  0x00007ffff059e06d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:111
(gdb)

It turns out it couldn't really work since one function pointer is
uninitialized. But nobody complained. Thus I investigated it further,
why it fails only for me. First, I tried a gtk3 version. And it works
properly, but the broken code is not hit at all. Due to the threaded
design, it was harder to figure out, why. Here is the code path:

-->
ev_window_load_job_cb          (shell/ev-window.c) -->
ev_document_model_set_document (libview/ev-document-model.c) -->
ev_view_document_changed_cb    (libview/ev-view.c) -->
setup_caches                   (libview/ev-view.c) -->

        if (ev_view_is_a11y_enabled (view)) {
                ev_page_cache_set_flags();
        }

ev_page_cache_set_flags        (libview/ev-page-cache.c) -->
ev_page_cache_set_page_range   (libview/ev-page-cache.c) -->

        data->job = ev_job_page_data_new (cache->document, i, flags);
        ...
        ev_job_scheduler_push_job (data->job, EV_JOB_PRIORITY_NONE);

...

-->
ev_job_thread_proxy            (libview/ev-job-scheduler.c) -->
ev_job_page_data_run           (libview/ev-jobs.c) -->
ev_document_links_get_links    (libdocument/ev-document-links.c) -->

        EvDocumentLinksInterface *iface = EV_DOCUMENT_LINKS_GET_IFACE (document_links);
        return iface->get_links (document_links, page);

(get_links == NULL) --> crash

As one can see it depends on the accessibility. And it is enabled on my
box.

It can be reproduced with
gsettings set org.mate.interface accessibility true
(mate logout and login)

Why the enabled accessibility is not discovered by the gtk3 version is
another story. My question [1] was motivated by this.

[1] https://github.com/mate-desktop/atril/issues/171