### PR TITLE
comics: MIME type fixes

### DIFF
--- a/backend/comics/comics-document.c
+++ b/backend/comics/comics-document.c
@@ -306,8 +306,8 @@ comics_check_decompress_command	(gchar          *mime_type,
 	/* FIXME, use proper cbr/cbz mime types once they're
 	 * included in shared-mime-info */
 	
-	if (!strcmp (mime_type, "application/x-cbr") ||
-	    !strcmp (mime_type, "application/x-rar")) {
+	if (g_content_type_is_a (mime_type, "application/x-cbr") ||
+	    g_content_type_is_a (mime_type, "application/x-rar")) {
 	        /* The RARLAB provides a no-charge proprietary (freeware) 
 	        * decompress-only client for Linux called unrar. Another 
 		* option is a GPLv2-licensed command-line tool developed by 
@@ -362,8 +362,8 @@ comics_check_decompress_command	(gchar          *mime_type,
 			return TRUE;
 		}
 
-	} else if (!strcmp (mime_type, "application/x-cbz") ||
-		   !strcmp (mime_type, "application/zip")) {
+	} else if (g_content_type_is_a (mime_type, "application/x-cbz") ||
+		   g_content_type_is_a (mime_type, "application/zip")) {
 		/* InfoZIP's unzip program */
 		comics_document->selected_command = 
 				g_find_program_in_path ("unzip");
@@ -381,8 +381,8 @@ comics_check_decompress_command	(gchar          *mime_type,
 			return TRUE;
 		}
 
-	} else if (!strcmp (mime_type, "application/x-cb7") ||
-		   !strcmp (mime_type, "application/x-7z-compressed")) {
+	} else if (g_content_type_is_a (mime_type, "application/x-cb7") ||
+		   g_content_type_is_a (mime_type, "application/x-7z-compressed")) {
 		/* 7zr, 7za and 7z are the commands from the p7zip project able 
 		 * to decompress .7z files */ 
 		comics_document->selected_command =
@@ -409,8 +409,8 @@ comics_check_decompress_command	(gchar          *mime_type,
 			comics_document->command_usage = TAR;
 			return TRUE;
 		}
-	} else if (!strcmp (mime_type, "application/x-cbt") ||
-		   !strcmp (mime_type, "application/x-tar")) {
+	} else if (g_content_type_is_a (mime_type, "application/x-cbt") ||
+		   g_content_type_is_a (mime_type, "application/x-tar")) {
 		/* tar utility (Tape ARchive) */
 		comics_document->selected_command =
 				g_find_program_in_path ("tar");

--- a/backend/comics/comicsdocument.atril-backend.in
+++ b/backend/comics/comicsdocument.atril-backend.in
@@ -1,4 +1,4 @@
 [Atril Backend]
 Module=comicsdocument
 _TypeDescription=Comic Books
-MimeType=application/x-cbr;application/x-cbz;application/x-cb7;application/x-cbt;
+MimeType=application/x-cbr;application/x-cbz;application/x-cb7;application/x-cbt;application/vnd.comicbook+zip;

--- a/configure.ac
+++ b/configure.ac
@@ -625,7 +625,7 @@ if test "x$enable_tiff" = "xyes"; then
     ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}image/tiff;"
 fi
 if test "x$enable_comics" = "xyes"; then
-    ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}application/x-cbr;application/x-cbz;application/x-cb7;application/x-cbt;"
+    ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}application/x-cbr;application/x-cbz;application/x-cb7;application/x-cbt;application/vnd.comicbook+zip;"
 fi
 if test "x$enable_pixbuf" = "xyes"; then
     ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}image/*;"


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/atril/issues/225 (I hope so).
More info at https://bugzilla.gnome.org/770903.

@raveit65 @lukefromdc @sc0w guys, if you have any .cbr/.cbz files, please test it. This is one more issue caused by newer shared-mime-info versions...
