### PR TITLE
comics backend: add support for unarchiver (unar and lsar)

### DIFF
--- a/backend/comics/comics-document.c
+++ b/backend/comics/comics-document.c
@@ -45,7 +45,8 @@ typedef enum
 	GNAUNRAR,
 	UNZIP,
 	P7ZIP,
-	TAR
+	TAR,
+	UNARCHIVER
 } ComicBookDecompressType;
 
 typedef struct _ComicsDocumentClass ComicsDocumentClass;
@@ -107,7 +108,10 @@ static const ComicBookDecompressCommand command_usage_def[] = {
 	{NULL               , "%s l -- %s"     , "%s x -y %s -o%s", FALSE, OFFSET_7Z},
 
         /* tar */
-	{"%s -xOf"          , "%s -tf %s"      , NULL             , FALSE, NO_OFFSET}
+	{"%s -xOf"          , "%s -tf %s"      , NULL             , FALSE, NO_OFFSET},
+
+	/* UNARCHIVER */
+	{"unar -o -"	    , "%s %s"	       , NULL		  , FALSE, NO_OFFSET}
 };
 
 static void       comics_document_document_thumbnails_iface_init (EvDocumentThumbnailsInterface *iface);
@@ -356,6 +360,12 @@ comics_check_decompress_command	(gchar          *mime_type,
 			return TRUE;
 		}
 		comics_document->selected_command =
+				g_find_program_in_path ("lsar");
+		if (comics_document->selected_command) {
+			comics_document->command_usage = UNARCHIVER;
+			return TRUE;
+		}
+		comics_document->selected_command =
 				g_find_program_in_path ("bsdtar");
 		if (comics_document->selected_command) {
 			comics_document->command_usage = TAR;
@@ -378,6 +388,12 @@ comics_check_decompress_command	(gchar          *mime_type,
 				g_find_program_in_path ("bsdtar");
 		if (comics_document->selected_command) {
 			comics_document->command_usage = TAR;
+			return TRUE;
+		}
+		comics_document->selected_command =
+				g_find_program_in_path ("lsar");
+		if (comics_document->selected_command) {
+			comics_document->command_usage = UNARCHIVER;
 			return TRUE;
 		}
 
@@ -409,6 +425,12 @@ comics_check_decompress_command	(gchar          *mime_type,
 			comics_document->command_usage = TAR;
 			return TRUE;
 		}
+		comics_document->selected_command =
+				g_find_program_in_path ("lsar");
+		if (comics_document->selected_command) {
+			comics_document->command_usage = UNARCHIVER;
+			return TRUE;
+		}
 	} else if (g_content_type_is_a (mime_type, "application/x-cbt") ||
 		   g_content_type_is_a (mime_type, "application/x-tar")) {
 		/* tar utility (Tape ARchive) */
@@ -422,6 +444,12 @@ comics_check_decompress_command	(gchar          *mime_type,
 				g_find_program_in_path ("bsdtar");
 		if (comics_document->selected_command) {
 			comics_document->command_usage = TAR;
+			return TRUE;
+		}
+		comics_document->selected_command =
+				g_find_program_in_path ("lsar");
+		if (comics_document->selected_command) {
+			comics_document->command_usage = UNARCHIVER;
 			return TRUE;
 		}
 	} else {


### PR DESCRIPTION
unar is able to extract all supported comics archive format

CBR
give unar priority over bsdtar, because it works better

CBZ CB7 CBT
give bsdtar priority over unar, because it is much faster