### PR TITLE
force X11

### DIFF
--- a/shell/main.c
+++ b/shell/main.c
@@ -234,6 +234,8 @@ main (int argc, char *argv[])
 	textdomain (GETTEXT_PACKAGE);
 #endif
 
+	gdk_set_allowed_backends ("x11");
+
 	context = g_option_context_new (N_("MATE Document Viewer"));
 	g_option_context_set_translation_domain(context, GETTEXT_PACKAGE);
 	g_option_context_add_main_entries (context, goption_options, GETTEXT_PACKAGE);


### PR DESCRIPTION
atril runs with this warning in gnome-wayland with this PR
```
[rave@f26 ~]$ atril
PlatformDisplayWayland initialization: failed to connect to the Wayland display: 
```
...whatever this means.
But it runs.