### PR TITLE
First page should not reloaded

### DIFF
--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -90,7 +90,7 @@ static gboolean      new_selection_surface_needed(EvPixbufCache      *pixbuf_cac
 #define PAGE_CACHE_LEN(pixbuf_cache) \
 	(pixbuf_cache->start_page>=0?((pixbuf_cache->end_page - pixbuf_cache->start_page) + 1):0)
 
-#define MAX_PRELOADED_PAGES 3
+#define MAX_PRELOADED_PAGES 20
 
 G_DEFINE_TYPE (EvPixbufCache, ev_pixbuf_cache, G_TYPE_OBJECT)
 

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -732,12 +732,13 @@ view_update_range_and_current_page (EvView *view)
 		}
 	}
 
+	#define PAGE_CACHE_NUMBER  10
 	ev_page_cache_set_page_range (view->page_cache,
-				      view->start_page,
-				      view->end_page);
+				      MAX(view->start_page - PAGE_CACHE_NUMBER, 0),
+				      MIN(view->end_page + PAGE_CACHE_NUMBER, ev_document_get_n_pages (view->document) - 1));
 	ev_pixbuf_cache_set_page_range (view->pixbuf_cache,
-					view->start_page,
-					view->end_page,
+					MAX(view->start_page - PAGE_CACHE_NUMBER, 0),
+					MIN(view->end_page + PAGE_CACHE_NUMBER, ev_document_get_n_pages (view->document) - 1),
 					view->selection_info.selections);
 
 	if (ev_pixbuf_cache_get_surface (view->pixbuf_cache, view->current_page))


### PR DESCRIPTION
For the displayed page, do not reload every time, should be displayed immediately
Tested successfully on Loongson 3A2000
with fedora25(mips64el distribution).