### PR TITLE
Previously opened page incorrectly restored if it was the last one

### DIFF
--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -1280,8 +1280,6 @@ setup_document_from_metadata (EvWindow *window)
 	 * show the first page. */
 	page = ev_document_model_get_page (window->priv->model);
 	n_pages = ev_document_get_n_pages (window->priv->document);
-	if (page == n_pages - 1)
-		ev_document_model_set_page (window->priv->model, 0);
 
 	if (ev_metadata_get_int (window->priv->metadata, "window_width", &width) &&
 	    ev_metadata_get_int (window->priv->metadata, "window_height", &height))


### PR DESCRIPTION
If you stay on the last page when you close it, reopen it will
not be positioned until you visited it (reset to the first).
In the changed code:
Judgment only works on the last page.
This function explicitly introduces this problem, so it can be
removed directly.
I have been tested successfully.