### PR TITLE
comics: Remove support for tar and tar-like commands

### DIFF
--- a/backend/comics/comics-document.c
+++ b/backend/comics/comics-document.c
@@ -45,7 +45,6 @@ typedef enum
 	GNAUNRAR,
 	UNZIP,
 	P7ZIP,
-	TAR,
 	UNARCHIVER
 } ComicBookDecompressType;
 
@@ -107,8 +106,6 @@ static const ComicBookDecompressCommand command_usage_def[] = {
         /* 7zip */
 	{NULL               , "%s l -- %s"     , "%s x -y %s -o%s", FALSE, OFFSET_7Z},
 
-        /* tar */
-	{"%s -xOf"          , "%s -tf %s"      , NULL             , FALSE, NO_OFFSET},
 
 	/* UNARCHIVER */
 	{"unar -o -"	    , "%s %s"	       , NULL		  , FALSE, NO_OFFSET}
@@ -365,12 +362,6 @@ comics_check_decompress_command	(gchar          *mime_type,
 			comics_document->command_usage = UNARCHIVER;
 			return TRUE;
 		}
-		comics_document->selected_command =
-				g_find_program_in_path ("bsdtar");
-		if (comics_document->selected_command) {
-			comics_document->command_usage = TAR;
-			return TRUE;
-		}
 
 	} else if (g_content_type_is_a (mime_type, "application/x-cbz") ||
 		   g_content_type_is_a (mime_type, "application/zip")) {
@@ -382,12 +373,6 @@ comics_check_decompress_command	(gchar          *mime_type,
 		if (comics_document->selected_command &&
 		    comics_document->alternative_command) {
 			comics_document->command_usage = UNZIP;
-			return TRUE;
-		}
-		comics_document->selected_command =
-				g_find_program_in_path ("bsdtar");
-		if (comics_document->selected_command) {
-			comics_document->command_usage = TAR;
 			return TRUE;
 		}
 		comics_document->selected_command =
@@ -420,38 +405,12 @@ comics_check_decompress_command	(gchar          *mime_type,
 			return TRUE;
 		}
 		comics_document->selected_command =
-				g_find_program_in_path ("bsdtar");
-		if (comics_document->selected_command) {
-			comics_document->command_usage = TAR;
-			return TRUE;
-		}
-		comics_document->selected_command =
 				g_find_program_in_path ("lsar");
 		if (comics_document->selected_command) {
 			comics_document->command_usage = UNARCHIVER;
 			return TRUE;
 		}
-	} else if (g_content_type_is_a (mime_type, "application/x-cbt") ||
-		   g_content_type_is_a (mime_type, "application/x-tar")) {
-		/* tar utility (Tape ARchive) */
-		comics_document->selected_command =
-				g_find_program_in_path ("tar");
-		if (comics_document->selected_command) {
-			comics_document->command_usage = TAR;
-			return TRUE;
-		}
-		comics_document->selected_command =
-				g_find_program_in_path ("bsdtar");
-		if (comics_document->selected_command) {
-			comics_document->command_usage = TAR;
-			return TRUE;
-		}
-		comics_document->selected_command =
-				g_find_program_in_path ("lsar");
-		if (comics_document->selected_command) {
-			comics_document->command_usage = UNARCHIVER;
-			return TRUE;
-		}
+
 	} else {
 		g_set_error (error,
 			     EV_DOCUMENT_ERROR,

--- a/backend/comics/comics-document.c
+++ b/backend/comics/comics-document.c
@@ -411,6 +411,16 @@ comics_check_decompress_command	(gchar          *mime_type,
 			return TRUE;
 		}
 
+	} else if (g_content_type_is_a (mime_type, "application/x-cbt") ||
+		   g_content_type_is_a (mime_type, "application/x-tar")) {
+		/* tar utility (Tape ARchive) */
+		comics_document->selected_command =
+				g_find_program_in_path ("lsar");
+		if (comics_document->selected_command) {
+			comics_document->command_usage = UNARCHIVER;
+			return TRUE;
+		}
+
 	} else {
 		g_set_error (error,
 			     EV_DOCUMENT_ERROR,

--- a/configure.ac
+++ b/configure.ac
@@ -600,7 +600,7 @@ if test "x$enable_tiff" = "xyes"; then
     ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}image/tiff;"
 fi
 if test "x$enable_comics" = "xyes"; then
-    ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}application/x-cbr;application/x-cbz;application/x-cb7;application/x-cbt;application/vnd.comicbook+zip;"
+    ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}application/x-cbr;application/x-cbz;application/x-cb7;application/vnd.comicbook+zip;"
 fi
 if test "x$enable_pixbuf" = "xyes"; then
     ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}image/*;"

--- a/configure.ac
+++ b/configure.ac
@@ -600,7 +600,7 @@ if test "x$enable_tiff" = "xyes"; then
     ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}image/tiff;"
 fi
 if test "x$enable_comics" = "xyes"; then
-    ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}application/x-cbr;application/x-cbz;application/x-cb7;application/vnd.comicbook+zip;"
+    ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}application/x-cbr;application/x-cbz;application/x-cb7;application/x-cbt;application/vnd.comicbook+zip;"
 fi
 if test "x$enable_pixbuf" = "xyes"; then
     ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}image/*;"


### PR DESCRIPTION
When handling tar files, or using a command with tar-compatible syntax,
to open comic-book archives, both the archive name (the name of the
comics file) and the filename (the name of a page within the archive)
are quoted to not be interpreted by the shell.

But the filename is completely with the attacker's control and can start
with "--" which leads to tar interpreting it as a command line flag.

This can be exploited by creating a CBT file (a tar archive with the
.cbt suffix) with an embedded file named something like this:
"--checkpoint-action=exec=bash -c 'touch ~/hacked;'.jpg"

CBT files are infinitely rare (CBZ is usually used for DRM-free
commercial releases, CBR for those from more dubious provenance), so
removing support is the easiest way to avoid the bug triggering. All
this code was rewritten in the development release for GNOME 3.26 to not
shell out to any command, closing off this particular attack vector.

This also removes the ability to use libarchive's bsdtar-compatible
binary for CBZ (ZIP), CB7 (7zip), and CBR (RAR) formats. The first two
are already supported by unzip and 7zip respectively. libarchive's RAR
support is limited, so unrar is a requirement anyway.

Discovered by Felix Wilhelm from the Google Security Team.

https://bugzilla.gnome.org/show_bug.cgi?id=784630

fixes https://github.com/mate-desktop/atril/issues/257