### PR TITLE
avoid GdkScreen deprecations

### DIFF
--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -375,9 +375,13 @@ gdouble
 ev_document_misc_get_screen_dpi (GdkScreen *screen, gint monitor)
 {
 	gdouble dp, di;
+	gint sc_width, sc_height;
+
+	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+				 &sc_width, &sc_height);
 
 	/*diagonal in pixels*/
-	dp = hypot (gdk_screen_get_width (screen), gdk_screen_get_height (screen));
+	dp = hypot (sc_width, sc_height);
 
 	/*diagonal in inches*/
 	di = hypot (gdk_screen_get_width_mm(screen), gdk_screen_get_height_mm (screen)) / 25.4;

--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -372,15 +372,14 @@ ev_document_misc_invert_pixbuf (GdkPixbuf *pixbuf)
 }
 
 gdouble
+#if GTK_CHECK_VERSION (3, 22, 0)
+ev_document_misc_get_screen_dpi (GdkScreen *screen, GdkMonitor *monitor)
+#else
 ev_document_misc_get_screen_dpi (GdkScreen *screen, gint monitor)
+#endif
 {
 	gdouble dp, di;
 	gint sc_width, sc_height;
-#if GTK_CHECK_VERSION (3, 22, 0)
-	GdkMonitor      *monitor_id;
-
-	monitor_id = gdk_display_get_monitor (gdk_screen_get_display (screen), monitor);
-#endif
 
 	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
 				 &sc_width, &sc_height);
@@ -390,12 +389,10 @@ ev_document_misc_get_screen_dpi (GdkScreen *screen, gint monitor)
 
 	/*diagonal in inches*/
 #if GTK_CHECK_VERSION (3, 22, 0)
-	di = hypot (gdk_monitor_get_width_mm(monitor_id), gdk_monitor_get_height_mm (monitor_id)) / 25.4;
+	di = hypot (gdk_monitor_get_width_mm(monitor), gdk_monitor_get_height_mm (monitor)) / 25.4;
+	di /= gdk_monitor_get_scale_factor (monitor);
 #else
 	di = hypot (gdk_screen_get_width_mm(screen), gdk_screen_get_height_mm (screen)) / 25.4;
-#endif
-
-#ifdef HAVE_HIDPI_SUPPORT
 	di /= gdk_screen_get_monitor_scale_factor(screen, monitor);
 #endif
 

--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -376,6 +376,11 @@ ev_document_misc_get_screen_dpi (GdkScreen *screen, gint monitor)
 {
 	gdouble dp, di;
 	gint sc_width, sc_height;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkMonitor      *monitor_id;
+
+	monitor_id = gdk_display_get_monitor (gdk_screen_get_display (screen), monitor);
+#endif
 
 	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
 				 &sc_width, &sc_height);
@@ -384,7 +389,11 @@ ev_document_misc_get_screen_dpi (GdkScreen *screen, gint monitor)
 	dp = hypot (sc_width, sc_height);
 
 	/*diagonal in inches*/
+#if GTK_CHECK_VERSION (3, 22, 0)
+	di = hypot (gdk_monitor_get_width_mm(monitor_id), gdk_monitor_get_height_mm (monitor_id)) / 25.4;
+#else
 	di = hypot (gdk_screen_get_width_mm(screen), gdk_screen_get_height_mm (screen)) / 25.4;
+#endif
 
 #ifdef HAVE_HIDPI_SUPPORT
 	di /= gdk_screen_get_monitor_scale_factor(screen, monitor);

--- a/libdocument/ev-document-misc.h
+++ b/libdocument/ev-document-misc.h
@@ -58,7 +58,11 @@ cairo_surface_t *ev_document_misc_surface_rotate_and_scale (cairo_surface_t *sur
 void             ev_document_misc_invert_surface (cairo_surface_t *surface);
 void		 ev_document_misc_invert_pixbuf  (GdkPixbuf       *pixbuf);
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+gdouble          ev_document_misc_get_screen_dpi (GdkScreen *screen, GdkMonitor *monitor);
+#else
 gdouble          ev_document_misc_get_screen_dpi (GdkScreen *screen, gint monitor);
+#endif
 
 gchar           *ev_document_misc_format_date (GTime utime);
 

--- a/libview/ev-annotation-window.c
+++ b/libview/ev-annotation-window.c
@@ -96,11 +96,21 @@ send_focus_change (GtkWidget *widget,
 static gdouble
 get_screen_dpi (EvAnnotationWindow *window)
 {
-	GdkScreen *screen;
-	gint monitor;
+	GdkScreen  *screen;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkMonitor *monitor;
+	GdkDisplay *display;
+#else
+	gint        monitor;
+#endif
 
 	screen = gtk_window_get_screen (GTK_WINDOW (window));
+#if GTK_CHECK_VERSION (3, 22, 0)
+	display = gdk_screen_get_display (screen);
+	monitor = gdk_display_get_primary_monitor (display);
+#else
 	monitor = gdk_screen_get_primary_monitor (screen);
+#endif
 	return ev_document_misc_get_screen_dpi (screen, monitor);
 }
 

--- a/libview/ev-view-presentation.c
+++ b/libview/ev-view-presentation.c
@@ -720,12 +720,16 @@ ev_view_presentation_goto_window_send_key_event (EvViewPresentation *pview,
 {
 	GdkEventKey *new_event;
 	GdkScreen   *screen;
+	gint         sc_width;
+	gint         sc_height;
 
 	/* Move goto window off screen */
 	screen = gtk_widget_get_screen (GTK_WIDGET (pview));
-	gtk_window_move (GTK_WINDOW (pview->goto_window),
-			 gdk_screen_get_width (screen) + 1,
-			 gdk_screen_get_height (screen) + 1);
+
+	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+				 &sc_width, &sc_height);
+
+	gtk_window_move (GTK_WINDOW (pview->goto_window), sc_width + 1, sc_height + 1);
 	gtk_widget_show (pview->goto_window);
 
 	new_event = (GdkEventKey *) gdk_event_copy (event);

--- a/libview/ev-view-presentation.c
+++ b/libview/ev-view-presentation.c
@@ -1213,12 +1213,23 @@ static gboolean
 init_presentation (GtkWidget *widget)
 {
 	EvViewPresentation *pview = EV_VIEW_PRESENTATION (widget);
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkDisplay         *display = gtk_widget_get_display (widget);
+	GdkRectangle        monitor;
+	GdkMonitor         *monitor_num;
+#else
 	GdkScreen          *screen = gtk_widget_get_screen (widget);
 	GdkRectangle        monitor;
 	gint                monitor_num;
+#endif
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+	monitor_num = gdk_display_get_monitor_at_window (display, gtk_widget_get_window (widget));
+	gdk_monitor_get_geometry (monitor_num, &monitor);
+#else
 	monitor_num = gdk_screen_get_monitor_at_window (screen, gtk_widget_get_window (widget));
 	gdk_screen_get_monitor_geometry (screen, monitor_num, &monitor);
+#endif
 	pview->monitor_width = monitor.width;
 	pview->monitor_height = monitor.height;
 

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -4449,15 +4449,19 @@ show_loading_window_cb (EvView *view)
 	if (!view->loading_window) {
 		GtkWindow *parent;
 		GdkScreen *screen;
+		gint       sc_width;
+		gint       sc_height;
 
 		parent = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (view)));
 		view->loading_window = ev_loading_window_new (parent);
 
 		/* Show the window off screen to get a valid size asap */
 		screen = gtk_widget_get_screen (GTK_WIDGET (view));
-		gtk_window_move (GTK_WINDOW (view->loading_window),
-				 gdk_screen_get_width (screen) + 1,
-				 gdk_screen_get_height (screen) + 1);
+
+		gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+					 &sc_width, &sc_height);
+
+		gtk_window_move (GTK_WINDOW (view->loading_window), sc_width + 1, sc_height + 1);
 		gtk_widget_show (view->loading_window);
 	}
 

--- a/previewer/ev-previewer-window.c
+++ b/previewer/ev-previewer-window.c
@@ -70,11 +70,21 @@ G_DEFINE_TYPE (EvPreviewerWindow, ev_previewer_window, GTK_TYPE_WINDOW)
 static gdouble
 get_screen_dpi (EvPreviewerWindow *window)
 {
-	GdkScreen *screen;
-	gint monitor;
+	GdkScreen  *screen;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkMonitor *monitor;
+	GdkDisplay *display;
+#else
+	gint        monitor;
+#endif
 
 	screen = gtk_window_get_screen (GTK_WINDOW (window));
+#if GTK_CHECK_VERSION (3, 22, 0)
+	display = gdk_screen_get_display (screen);
+	monitor = gdk_display_get_primary_monitor (display);
+#else
 	monitor = gdk_screen_get_primary_monitor (screen);
+#endif
 	return ev_document_misc_get_screen_dpi (screen, monitor);
 }
 

--- a/shell/ev-navigation-action-widget.c
+++ b/shell/ev-navigation-action-widget.c
@@ -131,18 +131,34 @@ menu_position_func (GtkMenu           *menu,
 	GtkTextDirection direction;
 	GdkWindow *gdk_window;
 	GdkRectangle monitor;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkMonitor *monitor_num;
+	GdkDisplay *display;
+#else
 	gint monitor_num;
 	GdkScreen *screen;
+#endif
 
 	gtk_widget_get_preferred_size (GTK_WIDGET (button->menu), &menu_req, NULL);
 	direction = gtk_widget_get_direction (widget);
+#if GTK_CHECK_VERSION (3, 22, 0)
+	display = gtk_widget_get_display (GTK_WIDGET (menu));
+#else
 	screen = gtk_widget_get_screen (GTK_WIDGET (menu));
+#endif
 
 	gdk_window = gtk_widget_get_window (widget);
+#if GTK_CHECK_VERSION (3, 22, 0)
+	monitor_num = gdk_display_get_monitor_at_window (display, gdk_window);
+	if (monitor_num == NULL)
+		monitor_num = gdk_display_get_monitor (display, 0);
+	gdk_monitor_get_geometry (monitor_num, &monitor);
+#else
 	monitor_num = gdk_screen_get_monitor_at_window (screen, gdk_window);
 	if (monitor_num < 0)
 		monitor_num = 0;
 	gdk_screen_get_monitor_geometry (screen, monitor_num, &monitor);
+#endif
 
 	gdk_window_get_origin (gdk_window, x, y);
 	gtk_widget_get_allocation (widget, &allocation);

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -383,11 +383,21 @@ G_DEFINE_TYPE (EvWindow, ev_window, GTK_TYPE_WINDOW)
 static gdouble
 get_screen_dpi (EvWindow *window)
 {
-	GdkScreen *screen;
-	gint monitor;
+	GdkScreen  *screen;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkMonitor *monitor;
+	GdkDisplay *display;
+#else
+	gint        monitor;
+#endif
 
 	screen = gtk_window_get_screen (GTK_WINDOW (window));
+#if GTK_CHECK_VERSION (3, 22, 0)
+	display = gdk_screen_get_display (screen);
+	monitor = gdk_display_get_primary_monitor (display);
+#else
 	monitor = gdk_screen_get_primary_monitor (screen);
+#endif
 	return ev_document_misc_get_screen_dpi (screen, monitor);
 }
 

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -1299,6 +1299,8 @@ setup_document_from_metadata (EvWindow *window)
 		GdkScreen *screen;
 		gint       request_width;
 		gint       request_height;
+		gint       sc_width;
+		gint       sc_height;
 
 		ev_document_get_max_page_size (window->priv->document,
 					       &document_width, &document_height);
@@ -1307,9 +1309,13 @@ setup_document_from_metadata (EvWindow *window)
 		request_height = (gint)(height_ratio * document_height + 0.5);
 
 		screen = gtk_window_get_screen (GTK_WINDOW (window));
+
+		gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
+					 &sc_width, &sc_height);
+
 		if (screen) {
-			request_width = MIN (request_width, gdk_screen_get_width (screen));
-			request_height = MIN (request_height, gdk_screen_get_height (screen));
+			request_width = MIN (request_width, sc_width);
+			request_height = MIN (request_height, sc_height);
 		}
 
 		if (request_width > 0 && request_height > 0) {


### PR DESCRIPTION
avoid deprecated:

- gdk_screen_get_width/height

- gdk_screen_get_width/height_mm (Fixes #177)

- gdk_screen_get_primary_monitor

- gdk_screen_get_monitor_scale_factor

- gdk_screen_get_monitor_geometry

- gdk_screen_get_monitor_at_window

- gdk_screen_get_monitor_at_point