### PR TITLE
shell: forward accels to the focused widget

### DIFF
--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -635,26 +635,34 @@ ev_window_update_actions (EvWindow *ev_window)
 	}
 }
 
+static const gchar *view_accels[] = {
+	"PageDown",
+	"PageUp",
+	"Plus",
+	"Minus",
+	"KpPlus",
+	"KpMinus",
+	"Equal",
+	"p",
+	"n",
+	"FitPage",
+	"FitWidth"
+};
+
 static void
 ev_window_set_view_accels_sensitivity (EvWindow *window, gboolean sensitive)
 {
 	gboolean can_find;
+	gint     i;
 
-	can_find = window->priv->document && 
-	    EV_IS_DOCUMENT_FIND (window->priv->document);
+	if (!window->priv->action_group)
+		return;
 
-	if (window->priv->action_group) {
-		ev_window_set_action_sensitive (window, "PageDown", sensitive);
-		ev_window_set_action_sensitive (window, "PageUp", sensitive);
-		ev_window_set_action_sensitive (window, "Plus", sensitive);
-		ev_window_set_action_sensitive (window, "Minus", sensitive);
-		ev_window_set_action_sensitive (window, "KpPlus", sensitive);
-		ev_window_set_action_sensitive (window, "KpMinus", sensitive);
-		ev_window_set_action_sensitive (window, "Equal", sensitive);
-		ev_window_set_action_sensitive (window, "p", sensitive);
-		ev_window_set_action_sensitive (window, "n", sensitive);
-		ev_window_set_action_sensitive (window, "Slash", sensitive && can_find);
-	}
+	for (i = 0; i < G_N_ELEMENTS (view_accels); i++)
+		ev_window_set_action_sensitive (window, view_accels[i], sensitive);
+
+	can_find = window->priv->document && EV_IS_DOCUMENT_FIND (window->priv->document);
+	ev_window_set_action_sensitive (window, "Slash", sensitive && can_find);
 }
 
 static void

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -6225,49 +6225,37 @@ menubar_deactivate_cb (GtkWidget *menubar,
 	update_chrome_visibility (window);
 }
 
+
+/*
+ * GtkWindow catches keybindings for the menu items _before_ passing them to
+ * the focused widget. This is unfortunate and means that pressing Ctrl+a,
+ * Ctrl+left or Ctrl+right in the search bar ends up selecting text in the EvView
+ * or rotating it.
+ * Here we override GtkWindow's handler to do the same things that it
+ * does, but in the opposite order and then we chain up to the grand
+ * parent handler, skipping gtk_window_key_press_event.
+ */
+
 static gboolean
 ev_window_key_press_event (GtkWidget   *widget,
 			   GdkEventKey *event)
 {
-	EvWindow        *ev_window = EV_WINDOW (widget);
-	EvWindowPrivate *priv = ev_window->priv;
-	gboolean         handled = FALSE;
+	static gpointer grand_parent_class = NULL;
+	GtkWindow *window = GTK_WINDOW (widget);
 
-	/* Propagate the event to the view first
-	 * It's needed to be able to type in
-	 * annot popups windows
-	 */
-	if ( priv->view) {  
-		g_object_ref (priv->view);
-		if (gtk_widget_is_sensitive (priv->view))
-			handled = gtk_widget_event (priv->view, (GdkEvent*) event);
-		g_object_unref (priv->view);
-	}
+	if (grand_parent_class == NULL)
+                grand_parent_class = g_type_class_peek_parent (ev_window_parent_class);
+
+        /* Handle focus widget key events */
+        if (gtk_window_propagate_key_event (window, event))
+		return TRUE;
 	
-	if (!handled && !EV_WINDOW_IS_PRESENTATION (ev_window)) {
-		guint modifier = event->state & gtk_accelerator_get_default_mod_mask ();
+	/* Handle mnemonics and accelerators */
+	if (gtk_window_activate_key (window, event))
+		return TRUE;
 
-		if (priv->menubar_accel_keyval != 0 &&
-		    event->keyval == priv->menubar_accel_keyval &&
-		    modifier == priv->menubar_accel_modifier) {
-			if (!gtk_widget_get_visible (priv->menubar)) {
-				g_signal_connect (priv->menubar, "deactivate",
-						  G_CALLBACK (menubar_deactivate_cb),
-						  ev_window);
-
-				gtk_widget_show (priv->menubar);
-				gtk_menu_shell_select_first (GTK_MENU_SHELL (priv->menubar),
-							     FALSE);
-
-				handled = TRUE;
-			}
-		}
-	}
-
-	if (!handled)
-		handled = GTK_WIDGET_CLASS (ev_window_parent_class)->key_press_event (widget, event);
-
-	return handled;
+        /* Chain up, invokes binding set on window */
+	return GTK_WIDGET_CLASS (grand_parent_class)->key_press_event (widget, event);
 }
 
 static gboolean

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -635,36 +635,6 @@ ev_window_update_actions (EvWindow *ev_window)
 	}
 }
 
-static const gchar *view_accels[] = {
-	"PageDown",
-	"PageUp",
-	"Plus",
-	"Minus",
-	"KpPlus",
-	"KpMinus",
-	"Equal",
-	"p",
-	"n",
-	"FitPage",
-	"FitWidth"
-};
-
-static void
-ev_window_set_view_accels_sensitivity (EvWindow *window, gboolean sensitive)
-{
-	gboolean can_find;
-	gint     i;
-
-	if (!window->priv->action_group)
-		return;
-
-	for (i = 0; i < G_N_ELEMENTS (view_accels); i++)
-		ev_window_set_action_sensitive (window, view_accels[i], sensitive);
-
-	can_find = window->priv->document && EV_IS_DOCUMENT_FIND (window->priv->document);
-	ev_window_set_action_sensitive (window, "Slash", sensitive && can_find);
-}
-
 static void
 set_widget_visibility (GtkWidget *widget, gboolean visible)
 {
@@ -6736,8 +6706,6 @@ view_actions_focus_in_cb (GtkWidget *widget, GdkEventFocus *event, EvWindow *win
 	update_chrome_flag (window, EV_CHROME_RAISE_TOOLBAR, FALSE);
 	ev_window_set_action_sensitive (window, "ViewToolbar", TRUE);
 
-	ev_window_set_view_accels_sensitivity (window, TRUE);
-
 	update_chrome_visibility (window);
 
 	return FALSE;
@@ -6746,8 +6714,6 @@ view_actions_focus_in_cb (GtkWidget *widget, GdkEventFocus *event, EvWindow *win
 static gboolean
 view_actions_focus_out_cb (GtkWidget *widget, GdkEventFocus *event, EvWindow *window)
 {
-	ev_window_set_view_accels_sensitivity (window, FALSE);
-
 	return FALSE;
 }
 
@@ -7790,8 +7756,6 @@ ev_window_init (EvWindow *ev_window)
 	accel_group =
 		gtk_ui_manager_get_accel_group (ev_window->priv->ui_manager);
 	gtk_window_add_accel_group (GTK_WINDOW (ev_window), accel_group);
-
-	ev_window_set_view_accels_sensitivity (ev_window, FALSE);
 
 	action_group = gtk_action_group_new ("ViewPopupActions");
 	ev_window->priv->view_popup_action_group = action_group;

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -6711,12 +6711,6 @@ view_actions_focus_in_cb (GtkWidget *widget, GdkEventFocus *event, EvWindow *win
 	return FALSE;
 }
 
-static gboolean
-view_actions_focus_out_cb (GtkWidget *widget, GdkEventFocus *event, EvWindow *window)
-{
-	return FALSE;
-}
-
 static void
 sidebar_page_main_widget_update_cb (GObject *ev_sidebar_page,
 				    GParamSpec         *pspec,
@@ -6729,9 +6723,6 @@ sidebar_page_main_widget_update_cb (GObject *ev_sidebar_page,
     	if (widget != NULL) {		
 		g_signal_connect_object (widget, "focus_in_event",
 				         G_CALLBACK (view_actions_focus_in_cb),
-					 ev_window, 0);
-		g_signal_connect_object (widget, "focus_out_event",
-				         G_CALLBACK (view_actions_focus_out_cb),
 					 ev_window, 0);
 		g_object_unref (widget);
 	}
@@ -7966,9 +7957,6 @@ ev_window_init (EvWindow *ev_window)
 	g_signal_connect_object (ev_window->priv->view, "focus_in_event",
 			         G_CALLBACK (view_actions_focus_in_cb),
 				 ev_window, 0);
-	g_signal_connect_object (ev_window->priv->view, "focus_out_event",
-			         G_CALLBACK (view_actions_focus_out_cb),
-			         ev_window, 0);
 	g_signal_connect_swapped (ev_window->priv->view, "external-link",
 				  G_CALLBACK (view_external_link_cb),
 				  ev_window);


### PR DESCRIPTION
GtkWindow catches keybindings for the menu items _before_ passing them to
the focused widget. This is unfortunate and means that pressing ctrl+Left
arrow, Ctrl+Right arrow on the search bar ends up turning the EvView
instead of moving around the text.
Here we override GtkWindow's handler to do the same things that it
does, but in the opposite order and then we chain up to the grand
parent handler, skipping gtk_window_key_press_event.

See https://bugzilla.gnome.org/show_bug.cgi?id=676040

inspired from https://git.gnome.org/browse/evince/commit/?id=70a2c0780b1b44acfa18f4762a3400b89eb123b5

fix rhbz https://bugzilla.redhat.com/show_bug.cgi?id=1513826

Please test