### PR TITLE
WidthOfScreen and HeightOfScreen implementation

### DIFF
--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -24,6 +24,7 @@
 #include <math.h>
 
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 
 #include "ev-document-misc.h"
 
@@ -401,13 +402,9 @@ ev_document_misc_get_screen_dpi (GdkScreen *screen, gint monitor)
 #endif
 {
 	gdouble dp, di;
-	gint sc_width, sc_height;
-
-	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-				 &sc_width, &sc_height);
 
 	/*diagonal in pixels*/
-	dp = hypot (sc_width, sc_height);
+	dp = hypot (WidthOfScreen (gdk_x11_screen_get_xscreen (screen)), HeightOfScreen (gdk_x11_screen_get_xscreen (screen)));
 
 	/*diagonal in inches*/
 #if GTK_CHECK_VERSION (3, 22, 0)

--- a/libview/ev-view-presentation.c
+++ b/libview/ev-view-presentation.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <glib/gi18n-lib.h>
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 #include <gdk/gdkkeysyms.h>
 
 #include "ev-view-presentation.h"
@@ -720,16 +721,12 @@ ev_view_presentation_goto_window_send_key_event (EvViewPresentation *pview,
 {
 	GdkEventKey *new_event;
 	GdkScreen   *screen;
-	gint         sc_width;
-	gint         sc_height;
 
 	/* Move goto window off screen */
 	screen = gtk_widget_get_screen (GTK_WIDGET (pview));
-
-	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-				 &sc_width, &sc_height);
-
-	gtk_window_move (GTK_WINDOW (pview->goto_window), sc_width + 1, sc_height + 1);
+	gtk_window_move (GTK_WINDOW (pview->goto_window),
+			 WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) + 1,
+			 HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) + 1);
 	gtk_widget_show (pview->goto_window);
 
 	new_event = (GdkEventKey *) gdk_event_copy (event);

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -26,6 +26,7 @@
 
 #include <glib/gi18n-lib.h>
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 #include <gdk/gdkkeysyms.h>
 
 #include "ev-mapping-list.h"
@@ -5723,19 +5724,15 @@ show_loading_window_cb (EvView *view)
 	if (!view->loading_window) {
 		GtkWindow *parent;
 		GdkScreen *screen;
-		gint       sc_width;
-		gint       sc_height;
 
 		parent = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (view)));
 		view->loading_window = ev_loading_window_new (parent);
 
 		/* Show the window off screen to get a valid size asap */
 		screen = gtk_widget_get_screen (GTK_WIDGET (view));
-
-		gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-					 &sc_width, &sc_height);
-
-		gtk_window_move (GTK_WINDOW (view->loading_window), sc_width + 1, sc_height + 1);
+		gtk_window_move (GTK_WINDOW (view->loading_window),
+				 WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) + 1,
+				 HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) + 1);
 		gtk_widget_show (view->loading_window);
 	}
 

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -40,6 +40,7 @@
 #include <glib/gi18n.h>
 #include <gio/gio.h>
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 
 #include "egg-editable-toolbar.h"
 #include "egg-toolbar-editor.h"
@@ -1337,8 +1338,6 @@ setup_document_from_metadata (EvWindow *window)
 		GdkScreen *screen;
 		gint       request_width;
 		gint       request_height;
-		gint       sc_width;
-		gint       sc_height;
 
 		ev_document_get_max_page_size (window->priv->document,
 					       &document_width, &document_height);
@@ -1347,13 +1346,9 @@ setup_document_from_metadata (EvWindow *window)
 		request_height = (gint)(height_ratio * document_height + 0.5);
 
 		screen = gtk_window_get_screen (GTK_WINDOW (window));
-
-		gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-					 &sc_width, &sc_height);
-
 		if (screen) {
-			request_width = MIN (request_width, sc_width);
-			request_height = MIN (request_height, sc_height);
+			request_width = MIN (request_width, WidthOfScreen (gdk_x11_screen_get_xscreen (screen)));
+			request_height = MIN (request_height, HeightOfScreen (gdk_x11_screen_get_xscreen (screen)));
 		}
 
 		if (request_width > 0 && request_height > 0) {


### PR DESCRIPTION
This commit reverts:

https://github.com/mate-desktop/atril/commit/d9fffe2dc0e33d6777099c18635b7b75f54d3d35

And it applies an alternative to fix the deprecated functions:

gdk_screen_get_width
gdk_screen_get_height