### PR TITLE
Fix make distcheck

### DIFF
--- a/properties/Makefile.am
+++ b/properties/Makefile.am
@@ -39,6 +39,17 @@ EXTRA_DIST = $(extension_in_files)
 
 CLEANFILES = $(extension_DATA)
 
+else
+
+extensiondir = $(datadir)/caja/extensions
+extension_in_files = libatril-properties-page.caja-extension.in
+extension_DATA = $(extension_in_files:.caja-extension.in=.caja-extension)
+%.caja-extension: %.caja-extension.in $(INTLTOOL_MERGE) $(wildcard $(top_srcdir)/po/*.po) ; $(AM_V_GEN) LC_ALL=C $(INTLTOOL_MERGE) -d -u -c $(top_builddir)/po/.intltool-merge-cache $(top_srcdir)/po $< $@
+
+EXTRA_DIST = $(extension_in_files)
+
+CLEANFILES = $(extension_DATA)
+
 endif # ENABLE_CAJA
 
 -include $(top_srcdir)/git.mk


### PR DESCRIPTION
`make distcheck` gave an error on atril/properties/libatril-properties-page.caja-extension.in, when building .pot file

distcheck is made with the `--disable-caja` config option.
This disables building the caja extension to preview documents (?) in caja.
I have added the same code and the problem is that the .caja-extension file is installed (at least in distcheck), so it is very likely, that caja would show the extension even if it is not actually there...

@monsta 
I may be misunderstanding something, but the .pot file is not generated normally for me here (, but also not on the mate-panel or on msa).
It is generated with distcheck, but then also deleted as I can't find it.
When is it supposed to be generated? or did you just mean that distcheck wasn't working with atril?

SO this is not a complete fix...
Ideas?

I though of making another config option, so that the extension is only built on normal install and if one asks for it specifically. This option would than have to be used for making the .pot file.

-----
note: checked out caja as well, it builds with make and make distcheck on master without errors.
same for mate-session-manager
pluma had a file missing from translations, make distcheck failed, created a PR.