### PR TITLE
Backports

### DIFF
--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -161,9 +161,11 @@ ev_document_misc_paint_one_page (cairo_t      *cr,
 	GtkStateFlags state = gtk_widget_get_state_flags (widget);
         GdkRGBA fg, bg, shade_bg;
 
+        gtk_style_context_save (context);
         gtk_style_context_get_background_color (context, state, &bg);
         gtk_style_context_get_color (context, state, &fg);
         gtk_style_context_get_color (context, state, &shade_bg);
+        gtk_style_context_restore (context);
         shade_bg.alpha *= 0.5;
 
 	gdk_cairo_set_source_rgba (cr, highlight ? &fg : &shade_bg);

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -3974,7 +3974,9 @@ get_cursor_color (GtkStyleContext *context,
 
 		gdk_color_free (style_color);
 	} else {
+		gtk_style_context_save (context);
 		gtk_style_context_get_color (context, GTK_STATE_FLAG_NORMAL, color);
+		gtk_style_context_restore (context);
 	}
 }
 
@@ -5622,7 +5624,9 @@ draw_rubberband (EvView             *view,
 	GdkRGBA          color;
 
 	context = gtk_widget_get_style_context (GTK_WIDGET (view));
+	gtk_style_context_save (context);
 	gtk_style_context_get_background_color (context, GTK_STATE_FLAG_SELECTED, &color);
+	gtk_style_context_restore (context);
 
 	cairo_save (cr);
 
@@ -5811,12 +5815,15 @@ _ev_view_get_selection_colors (EvView  *view,
 
 	state = gtk_widget_has_focus (widget) ? GTK_STATE_FLAG_SELECTED : GTK_STATE_FLAG_ACTIVE;
 	context = gtk_widget_get_style_context (widget);
+	gtk_style_context_save (context);
 
 	if (bg_color)
 		gtk_style_context_get_background_color (context, state, bg_color);
 
 	if (fg_color)
 		gtk_style_context_get_color (context, state, fg_color);
+
+	gtk_style_context_restore (context);
 }
 
 static void

--- a/libview/ev-web-view.c
+++ b/libview/ev-web-view.c
@@ -252,6 +252,9 @@ ev_web_view_inverted_colors_changed_cb (EvDocumentModel *model,
 				        EvWebView       *webview)
 {
 	EvDocument *document = ev_document_model_get_document(model);
+
+	if (!document || !document->iswebdocument)
+	    return;
 	
 	if (ev_document_model_get_inverted_colors(model) == TRUE) {
 		if (document == NULL) {


### PR DESCRIPTION
Some backports from xreader.
- Save/restore context when getting colors for a different state
- libview: save inverted colors in a document

Please test.
