### PR TITLE
Basic backports

### DIFF
--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -229,68 +229,10 @@ ev_document_misc_pixbuf_from_surface (cairo_surface_t *surface)
 {
 	g_return_val_if_fail (surface, NULL);
 
-	GdkPixbuf       *pixbuf;
-	cairo_surface_t *image;
-	cairo_t         *cr;
-	gboolean         has_alpha;
-	gint             width, height;
-	cairo_format_t   surface_format;
-	gint             pixbuf_n_channels;
-	gint             pixbuf_rowstride;
-	guchar          *pixbuf_pixels;
-	gint             x, y;
-
-	width = cairo_image_surface_get_width (surface);
-	height = cairo_image_surface_get_height (surface);
-	
-	surface_format = cairo_image_surface_get_format (surface);
-	has_alpha = (surface_format == CAIRO_FORMAT_ARGB32);
-
-	pixbuf = gdk_pixbuf_new (GDK_COLORSPACE_RGB,
-				 TRUE, 8,
-				 width, height);
-	pixbuf_n_channels = gdk_pixbuf_get_n_channels (pixbuf);
-	pixbuf_rowstride = gdk_pixbuf_get_rowstride (pixbuf);
-	pixbuf_pixels = gdk_pixbuf_get_pixels (pixbuf);
-
-	image = cairo_image_surface_create_for_data (pixbuf_pixels,
-						     surface_format,
-						     width, height,
-						     pixbuf_rowstride);
-	cr = cairo_create (image);
-	cairo_set_source_surface (cr, surface, 0, 0);
-
-	if (has_alpha)
-		cairo_mask_surface (cr, surface, 0, 0);
-	else
-		cairo_paint (cr);
-
-	cairo_destroy (cr);
-	cairo_surface_destroy (image);
-
-	for (y = 0; y < height; y++) {
-		guchar *p = pixbuf_pixels + y * pixbuf_rowstride;
-
-		for (x = 0; x < width; x++) {
-			guchar tmp;
-			
-#if G_BYTE_ORDER == G_LITTLE_ENDIAN
-			tmp = p[0];
-			p[0] = p[2];
-			p[2] = tmp;
-			p[3] = (has_alpha) ? p[3] : 0xff;
-#else
-			tmp = p[0];
-			p[0] = p[1];
-			p[1] = p[2];
-			p[2] = p[3];
-			p[3] = (has_alpha) ? tmp : 0xff;
-#endif			
-			p += pixbuf_n_channels;
-		}
-	}
-
-	return pixbuf;
+    return gdk_pixbuf_get_from_surface (surface,
+                                        0, 0,
+                                        cairo_image_surface_get_width (surface),
+                                        cairo_image_surface_get_height (surface));
 }
 
 cairo_surface_t *

--- a/thumbnailer/Makefile.am
+++ b/thumbnailer/Makefile.am
@@ -6,11 +6,8 @@ atril_thumbnailer_SOURCES = \
 	atril-thumbnailer.c
 
 atril_thumbnailer_CPPFLAGS = \
-	-DATRILDATADIR=\"$(pkgdatadir)\"	\
 	-I$(top_srcdir)				\
 	-I$(top_builddir)			\
-	-DMATELOCALEDIR=\"$(datadir)/locale\"	\
-	-DMATEICONDIR=\""$(datadir)/pixmaps"\" \
 	$(AM_CPPFLAGS)
 
 atril_thumbnailer_CFLAGS = \

--- a/thumbnailer/atril-thumbnailer.c
+++ b/thumbnailer/atril-thumbnailer.c
@@ -174,34 +174,6 @@ atril_thumbnail_pngenc_get (EvDocument *document, const char *thumbnail, int siz
 	g_object_unref (page);
 	
 	if (pixbuf != NULL) {
-		const char *overlaid_icon_name = NULL;
-
-		if (overlaid_icon_name) {
-			GdkPixbuf *overlaid_pixbuf;
-
-			gchar *overlaid_icon_path = g_strdup_printf ("%s/%s", ATRILDATADIR, overlaid_icon_name);
-			overlaid_pixbuf = gdk_pixbuf_new_from_file (overlaid_icon_path, NULL);
-			g_free (overlaid_icon_path);
-			if (overlaid_pixbuf != NULL) {
-				int delta_height, delta_width;
-				
-				delta_width = gdk_pixbuf_get_width (pixbuf) -
-					gdk_pixbuf_get_width (overlaid_pixbuf);
-				delta_height = gdk_pixbuf_get_height (pixbuf) -
-					gdk_pixbuf_get_height (overlaid_pixbuf);
-				
-				gdk_pixbuf_composite (overlaid_pixbuf, pixbuf,
-						      delta_width, delta_height,
-						      gdk_pixbuf_get_width (overlaid_pixbuf),
-						      gdk_pixbuf_get_height (overlaid_pixbuf),
-						      delta_width, delta_height,
-						      1, 1,
-						      GDK_INTERP_NEAREST, 100);
-				
-				g_object_unref  (overlaid_pixbuf);
-			}
-		}
-		
 		if (gdk_pixbuf_save (pixbuf, thumbnail, "png", NULL, NULL)) {
 			g_object_unref  (pixbuf);
 			return TRUE;


### PR DESCRIPTION
- backend: Remove pixbuf backend
Evince is a document viewer, not an image viewer. Eog does the latter job
much better than evince ever could

- thumbnailer: Remove unused code
The code to overlay an icon is unused since commit (2005)
https://git.gnome.org/browse/evince/commit/?id=808285c

Please test.



