### PR TITLE
Fix presentation actions

### DIFF
--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -514,6 +514,7 @@ ev_window_setup_action_sensitivity (EvWindow *ev_window)
 	ev_window_set_action_sensitive (ev_window, PAGE_SELECTOR_ACTION, has_pages);
 	ev_window_set_action_sensitive (ev_window, ZOOM_CONTROL_ACTION,  has_pages);
 	ev_window_set_action_sensitive (ev_window, NAVIGATION_ACTION,  FALSE);
+	ev_window_set_action_sensitive (ev_window, "StartPresentation", has_pages);
 
         ev_window_update_actions (ev_window);
 }

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -483,7 +483,7 @@ ev_window_setup_action_sensitivity (EvWindow *ev_window)
 	ev_window_set_action_sensitive (ev_window, "FilePrint", has_pages && ok_to_print);
 	ev_window_set_action_sensitive (ev_window, "FileProperties", has_document && has_properties);
 	ev_window_set_action_sensitive (ev_window, "FileSendTo", has_document);
-	ev_window_set_action_sensitive (ev_window, "ViewPresentation", has_document);
+	ev_window_set_action_sensitive (ev_window, "ViewPresentation", has_pages);
 
         /* Edit menu */
 	ev_window_set_action_sensitive (ev_window, "EditSelectAll", has_pages && can_get_text);


### PR DESCRIPTION
To test the first commit:
- open truncated pdf (like [this one](https://bugzilla.redhat.com/show_bug.cgi?id=1536856#c20))
- press F5
- nothing should happen

Without the fix, you'll get to fullscreen (like with F11) and see some warnings in the terminal.

To test the second commit:
- open atril w/o documents or with truncated pdf
- press F11 to get to fullscreen
- Start Presentation button should be disabled

Without the fix, Start Presentation button is enabled. Clicking on it w/o documents makes atril crash. Clicking on it with truncated pdf leads to some warnings in the terminal.