### PR TITLE
comics: fix incorrect mimetype which said to open and thumbnail all rar files

### DIFF
--- a/backend/comics/comicsdocument.atril-backend.in
+++ b/backend/comics/comicsdocument.atril-backend.in
@@ -1,4 +1,4 @@
 [Atril Backend]
 Module=comicsdocument
 _TypeDescription=Comic Books
-MimeType=application/x-cbr;application/x-cbz;application/x-cb7;application/x-cbt;application/vnd.comicbook+zip;application/vnd.rar;
+MimeType=application/x-cbr;application/x-cbz;application/x-cb7;application/x-cbt;application/vnd.comicbook+zip;application/vnd.comicbook-rar;

--- a/configure.ac
+++ b/configure.ac
@@ -639,7 +639,7 @@ if test "x$enable_tiff" = "xyes"; then
     ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}image/tiff;"
 fi
 if test "x$enable_comics" = "xyes"; then
-    ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}application/x-cbr;application/x-cbz;application/x-cb7;application/x-cbt;application/vnd.comicbook+zip;application/vnd.rar;"
+    ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}application/x-cbr;application/x-cbz;application/x-cb7;application/x-cbt;application/vnd.comicbook+zip;application/vnd-comicbook.rar;"
 fi
 if test "x$enable_pixbuf" = "xyes"; then
     ATRIL_MIME_TYPES="${ATRIL_MIME_TYPES}image/*;"


### PR DESCRIPTION
application/vnd.rar is for files with the .rar extension, application/vnd.comicbook-rar is the subtype for files with the .cbr extension.

This properly fixes #341