### PR TITLE
Change url project's website

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ m4_define([ev_binary_version], [ev_document_lt_current])
 # *****************************************************************************
 
 AC_PREREQ([2.57])
-AC_INIT([atril], [ev_version], [http://www.mate-desktop.org/], [atril])
+AC_INIT([atril], [ev_version], [https://mate-desktop.org/], [atril])
 AM_INIT_AUTOMAKE([1.10 foreign tar-ustar dist-xz no-dist-gzip check-news])
 
 AC_CONFIG_HEADERS([config.h])

--- a/data/atril.appdata.xml.in
+++ b/data/atril.appdata.xml.in
@@ -38,7 +38,7 @@
    </image>
   </screenshot>
  </screenshots>
- <url type="homepage">http://www.mate-desktop.org</url>
+ <url type="homepage">https://mate-desktop.org</url>
  <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
  <project_group>MATE</project_group>
 </component>

--- a/previewer/atril-previewer.1
+++ b/previewer/atril-previewer.1
@@ -13,4 +13,4 @@ command line options.
 \fBatril\fR(1),
 \fBgtk\-options\fR(7).
 .PP
-http://www.mate-desktop.org/
+https://mate-desktop.org/

--- a/properties/libatril-properties-page.caja-extension.in.in
+++ b/properties/libatril-properties-page.caja-extension.in.in
@@ -4,5 +4,5 @@ _Name=Atril properties
 _Description=Shows details for Atril documents
 Version=@VERSION@
 Author=Andrew Sobala <aes@gnome.org>;Bastien Nocera <hadess@hadess.net>
-Website=http://www.mate-desktop.org/
+Website=https://mate-desktop.org/
 Copyright=Copyright (C) 2000, 2001 Eazel Inc.\nCopyright (C) 2003 Andrew Sobala <aes@gnome.org>\nCopyright (C) 2005 Bastien Nocera <hadess@hadess.net>\nCopyright (C) 2005 Red Hat, Inc\nCopyright (C) 2012–2018 The MATE developers

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -5368,7 +5368,7 @@ ev_window_cmd_help_about (GtkAction *action, EvWindow *ev_window)
 		"copyright", _("Copyright \xc2\xa9 1996–2009 The Evince authors\n"
 		               "Copyright \xc2\xa9 2012–2019 The MATE developers"),
 		"license", license_trans,
-		"website", "http://www.mate-desktop.org/",
+		"website", "https://mate-desktop.org/",
 		"comments", comments,
 		"authors", authors,
 		"documenters", documenters,

--- a/thumbnailer/atril-thumbnailer.1
+++ b/thumbnailer/atril-thumbnailer.1
@@ -15,4 +15,4 @@ of the created thumbnail.
 \fBatril\fR(1),
 \fBgtk\-options\fR(7).
 .PP
-http://www.mate-desktop.org//
+https://mate-desktop.org//


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.