### PR TITLE
migrate to python3 for test cases

### DIFF
--- a/test/test1.py
+++ b/test/test1.py
@@ -1,36 +1,38 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # This test opens the interface and just clicks around a bit.
 
 import os
-os.environ['LANG']='C'
+import dogtail.config
+dogtail.config.config.logDebugToStdOut = True
+dogtail.config.config.logDebugToFile = False
 
 from dogtail.procedural import *
 
+os.environ['LANG']='C'
 run('atril')
 
 # Test file->open
+focus.application('atril')
 click('File', roleName='menu')
-click('Open...', roleName='menu item')
-focus.dialog('Open Document')
+click('Open…', roleName='menu item')
 click('Cancel', roleName='push button')
 
 # Toolbar editor
+focus.application('atril')
 click('Edit', roleName='menu')
 click('Toolbar', roleName='menu item')
-focus.dialog('Toolbar Editor')
 click('Close', roleName='push button')
 
 # About dialog
+focus.application('atril')
 click('Help', roleName='menu')
 click('About', roleName='menu item')
-focus.dialog('About Document Viewer')
-click('Credits', roleName='push button')
-focus.dialog('Credits')
-click('Close', roleName='push button')
-focus.dialog('About Document Viewer')
+click('Credits', roleName='toggle button')
+click('Credits', roleName='toggle button')
 click('Close', roleName='push button')
 
 # Close atril
-click('File', roleName='menu')
+focus.application('atril')
+click.menu('File')
 click('Close', roleName='menu item')

--- a/test/test2.py
+++ b/test/test2.py
@@ -11,6 +11,7 @@ from dogtail.procedural import *
 run('atril', arguments=' '+srcdir+'/test-encrypt.pdf')
 
 # Try an incorrect password first
+focus.application('atril')
 type('wrong password')
 click('Unlock Document', roleName='push button')
 focus.dialog('Enter password')

--- a/test/test2.py
+++ b/test/test2.py
@@ -18,7 +18,7 @@ focus.dialog('Enter password')
 click('Cancel', roleName='push button')
 
 # Try again with the correct password
-focus.application('atril')
+focus.frame('test-encrypt.pdf — Password Required')
 click('Unlock Document', roleName='push button')
 focus.dialog('Enter password')
 type('Foo')

--- a/test/test2.py
+++ b/test/test2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # This test opens a password encrypted file and tries to unlock it.
 
@@ -11,18 +11,19 @@ from dogtail.procedural import *
 run('atril', arguments=' '+srcdir+'/test-encrypt.pdf')
 
 # Try an incorrect password first
-focus.dialog('Enter password')
-focus.widget('Password Entry', roleName='password text')
 type('wrong password')
 click('Unlock Document', roleName='push button')
+focus.dialog('Enter password')
 click('Cancel', roleName='push button')
 
 # Try again with the correct password
+focus.application('atril')
 click('Unlock Document', roleName='push button')
-focus.widget('Password Entry', roleName='password text')
+focus.dialog('Enter password')
 type('Foo')
 click('Unlock Document', roleName='push button')
 
 # Close atril
+focus.application('atril')
 click('File', roleName='menu')
 click('Close', roleName='menu item')

--- a/test/test3.py
+++ b/test/test3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # This test opens a file with wrong extenstion.
 

--- a/test/test3.py
+++ b/test/test3.py
@@ -11,5 +11,6 @@ from dogtail.procedural import *
 run('atril', arguments=' '+srcdir+'/test-mime.bin')
 
 # Close atril
+focus.application('atril')
 click('File', roleName='menu')
 click('Close', roleName='menu item')

--- a/test/test4.py
+++ b/test/test4.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # This test tries document reload action.
 
@@ -12,9 +12,11 @@ run('atril', arguments=' '+srcdir+'/test-links.pdf')
 
 # Reload document a few times
 for i in range(1,6):
-	click('View', roleName='menu')
-	click('Reload', roleName='menu item')
+    focus.application('atril')
+    click('View', roleName='menu')
+    click('Reload', roleName='menu item')
 
 # Close atril
+focus.application('atril')
 click('File', roleName='menu')
 click('Close', roleName='menu item')

--- a/test/test5.py
+++ b/test/test5.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # This test tries document reload action.
 
@@ -15,10 +15,11 @@ focus.widget.text = "iii"
 activate()
 
 if focus.widget.text != "III":
-	click('File', roleName='menu')
-	click('Close', roleName='menu item')
-	exit (1)
+    click('File', roleName='menu')
+    click('Close', roleName='menu item')
+    exit (1)
 
 # Close atril
+focus.application('atril')
 click('File', roleName='menu')
 click('Close', roleName='menu item')

--- a/test/test5.py
+++ b/test/test5.py
@@ -10,11 +10,13 @@ from dogtail.procedural import *
 
 run('atril', arguments=' '+srcdir+'/test-page-labels.pdf')
 
+focus.application('atril')
 focus.widget('page-label-entry')
 focus.widget.text = "iii"
 activate()
 
 if focus.widget.text != "III":
+    focus.application('atril')
     click('File', roleName='menu')
     click('Close', roleName='menu item')
     exit (1)

--- a/test/test6.py
+++ b/test/test6.py
@@ -25,6 +25,7 @@ if os.path.exists(ps_file):
 
 run('atril', arguments=' '+srcdir+'/test-page-labels.pdf')
 
+focus.application('atril')
 click('File', roleName='menu')
 click('Print…', roleName='menu item')
 

--- a/test/test6.py
+++ b/test/test6.py
@@ -1,31 +1,46 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # Test printing
 
 import os
+import dogtail.config
+dogtail.config.config.logDebugToStdOut = True
+dogtail.config.config.logDebugToFile = False
+
 os.environ['LANG']='C'
 srcdir = os.environ['srcdir']
-homedir = os.environ["HOME"] + "/";
 
 from dogtail.procedural import *
 
-if os.path.exists(homedir + "output.ps"):
-    os.unlink(homedir + "output.ps")
+recent_used = os.path.expanduser('~/.local/share/recently-used.xbel')
+recent_used_orig = recent_used + '.orig'
+
+ps_file = os.path.expanduser('~/output.ps')
+
+if os.path.isfile(recent_used):
+    os.rename(recent_used, recent_used_orig)
+
+if os.path.exists(ps_file):
+    os.unlink(ps_file)
 
 run('atril', arguments=' '+srcdir+'/test-page-labels.pdf')
 
 click('File', roleName='menu')
-click('Print...', roleName='menu item')
+click('Print…', roleName='menu item')
 
-focus.dialog('Print')
 click('Print to File', roleName='table cell', raw=True)
+click('Postscript', roleName='radio button', raw=True)
 click('Print', roleName='push button')
 
-statinfo = os.stat (homedir + "output.ps")
+statinfo = os.stat (ps_file)
 if statinfo.st_size > 100000:
     exit(1)
-os.unlink (homedir + "output.ps")
+os.unlink (ps_file)
 
 # Close atril
+focus.application('atril')
 click('File', roleName='menu')
 click('Close', roleName='menu item')
+
+if os.path.isfile(recent_used_orig):
+    os.rename(recent_used_orig, recent_used)

--- a/test/test7.py
+++ b/test/test7.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # Test printing
 

--- a/test/test7.py
+++ b/test/test7.py
@@ -3,6 +3,11 @@
 # Test printing
 
 import os
+import dogtail.config
+import time
+dogtail.config.config.logDebugToStdOut = True
+dogtail.config.config.logDebugToFile = False
+
 os.environ['LANG']='C'
 srcdir = os.environ['srcdir']
 
@@ -10,24 +15,22 @@ from dogtail.procedural import *
 
 run('atril', arguments=' '+srcdir+'/test-page-labels.pdf')
 
-#!/usr/bin/python
-from dogtail.procedural import *
-
 focus.application('atril')
 focus.frame('test-page-labels.pdf')
 click('File', roleName='menu')
-click('Print...', roleName='menu item')
+click('Print…', roleName='menu item')
 focus.dialog('Print')
 click('Pages:', roleName='radio button')
-keyCombo('Tab')
+focus.text('Pages')
 type('1')
+focus.dialog('Print')
 click('Page Setup', roleName='page tab', raw=True)
 click('All sheets')
-click('Even sheets')
-click('Print Preview', roleName='push button')
-keyCombo('Return')
-click('Cancel')
+click('Odd sheets', roleName='menu item')
+click('Preview', roleName='push button')
+keyCombo('<Alt><F4>')
 
 # Close atril
+focus.application('atril')
 click('File', roleName='menu')
 click('Close', roleName='menu item')


### PR DESCRIPTION
May be it is the last part of mate-desktop is not working with python3.

This changes need to run with dogtail, it's a GUI test tool and automation framework, It is based on accessibility and I think it's amazing.

Please use the last release version of dogtail: https://gitlab.com/dogtail/dogtail/-/tags/DOGTAIL_0_9_11

Please configure with:
```
./configure --enable-tests
```
Run test use:
```
make check
```