### PR TITLE
Bump Cairo version to 1.14.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,7 +82,7 @@ AC_SUBST([EV_INTLTOOL_ATRIL_BACKEND_RULE])
 GLIB_GSETTINGS
 
 dnl Specify required versions of dependencies
-CAIRO_REQUIRED=1.10.0
+CAIRO_REQUIRED=1.14.0
 GLIB_REQUIRED=2.50.0
 GTK_REQUIRED=3.22.0
 WEBKIT_REQUIRED=2.4.3
@@ -137,23 +137,6 @@ AC_ARG_VAR([XMLLINT],[the xmllint programme])
 AC_PATH_PROG([XMLLINT],[xmllint],[])
 if test -z "$XMLLINT"; then
   AC_MSG_ERROR([xmllint not found])
-fi
-
-# Although GTK+ 3.10 includes hi-dpi functionality, it does not require a cairo with
-# cairo_surface_set_device_scale(), which we also need if we're to support hi-dpi,
-# so we need check for that explicity.
-
-atril_save_LIBS=$LIBS
-LIBS="$LIBS $LIBVIEW_LIBS"
-AC_CHECK_FUNCS(cairo_surface_set_device_scale)
-LIBS=$atril_save_LIBS
-
-AC_MSG_CHECKING([for hi-dpi support])
-if test "$ac_cv_func_cairo_surface_set_device_scale" = yes ; then
-   AC_DEFINE([HAVE_HIDPI_SUPPORT], [1], [Define if cairo and GTK+ have necessary functions for hi-dpi])
-   AC_MSG_RESULT([yes])
-else
-   AC_MSG_RESULT([no])
 fi
 
 dnl

--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -251,22 +251,14 @@ ev_pixbuf_cache_set_max_size (EvPixbufCache *pixbuf_cache,
 static int
 get_device_scale (EvPixbufCache *pixbuf_cache)
 {
-#ifdef HAVE_HIDPI_SUPPORT
 	return gtk_widget_get_scale_factor (pixbuf_cache->view);
-#else
-	return 1;
-#endif
 }
 
 static void
 set_device_scale_on_surface (cairo_surface_t *surface,
                              int              device_scale)
 {
-#ifdef HAVE_HIDPI_SUPPORT
 	cairo_surface_set_device_scale (surface, device_scale, device_scale);
-#else
-	g_return_if_fail (device_scale == 1);
-#endif
 }
 
 static void

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -5707,9 +5707,7 @@ draw_surface (cairo_t 	      *cr,
 	gdouble width, height;
 	gdouble device_scale_x = 1, device_scale_y = 1;
 
-#ifdef HAVE_HIDPI_SUPPORT
 	cairo_surface_get_device_scale (surface, &device_scale_x, &device_scale_y);
-#endif
 	width = cairo_image_surface_get_width (surface) / device_scale_x;
 	height = cairo_image_surface_get_height (surface) / device_scale_y;
 
@@ -5841,9 +5839,7 @@ draw_one_page (EvView       *view,
 			return;
 		}
 
-#ifdef HAVE_HIDPI_SUPPORT
 		cairo_surface_get_device_scale (page_surface, &device_scale_x, &device_scale_y);
-#endif
 
 		if (page == current_page)
 			ev_view_set_loading (view, FALSE);
@@ -5878,9 +5874,7 @@ draw_one_page (EvView       *view,
 			scale_x = (gdouble)width / cairo_image_surface_get_width (page_surface);
 			scale_y = (gdouble)height / cairo_image_surface_get_height (page_surface);
 
-#ifdef HAVE_HIDPI_SUPPORT
 			cairo_surface_get_device_scale (page_surface, &device_scale_x, &device_scale_y);
-#endif
 
 			scale_x *= device_scale_x;
 			scale_y *= device_scale_y;


### PR DESCRIPTION
such that hi-dpi conditionals aren't needed.

origin commit:
https://github.com/linuxmint/xreader/commit/df3cdc6