### PR TITLE
Fix buffer overflow in backend/tiff-document.c

### DIFF
--- a/backend/tiff/tiff-document.c
+++ b/backend/tiff/tiff-document.c
@@ -268,13 +268,14 @@ tiff_document_render (EvDocument      *document,
 		return NULL;                
 	}
 	
-	bytes = height * rowstride;
-	if (bytes / rowstride != height) {
+	if (height >= INT_MAX / rowstride) {
 		g_warning("Overflow while rendering document.");
 		/* overflow */
 		return NULL;
 	}
 	
+	bytes = height * rowstride;
+
 	pixels = g_try_malloc (bytes);
 	if (!pixels) {
 		g_warning("Failed to allocate memory for rendering.");
@@ -356,15 +357,17 @@ tiff_document_render_pixbuf (EvDocument      *document,
 	if (width <= 0 || height <= 0)
 		return NULL;                
 
-	rowstride = width * 4;
-	if (rowstride / 4 != width)
+	if (width >= INT_MAX / 4)
 		/* overflow */
 		return NULL;                
         
-	bytes = height * rowstride;
-	if (bytes / rowstride != height)
+	rowstride = width * 4;
+
+	if (height >= INT_MAX / rowstride)
 		/* overflow */
-		return NULL;                
+		return NULL; 
+
+	bytes = height * rowstride;               
 	
 	pixels = g_try_malloc (bytes);
 	if (!pixels)


### PR DESCRIPTION
Apply https://gitlab.gnome.org/GNOME/evince/commit/e02fe9170ad0ac2fd46c75329c4f1d4502d4a362

Backport of https://github.com/mate-desktop/atril/pull/387/commits/3829e99d752bb9737826a94880666c4d98de3dab to 1.22