### PR TITLE
Suppress GtkAction deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -189,6 +189,12 @@ variables:
     -enable-checker alpha.core.FixedAddr
     -enable-checker security.insecureAPI.strcpy"'
 
+before_scripts:
+  - if [ ${DISTRO_NAME} == "debian" ];then
+  -     egrep -lRZ 'G_GNUC_BEGIN_IGNORE_DEPRECATIONS' . | xargs -0 -l sed -i -e 's/G_GNUC_BEGIN_IGNORE_DEPRECATIONS/ /g'
+  -     egrep -lRZ 'G_GNUC_END_IGNORE_DEPRECATIONS' . | xargs -0 -l sed -i -e 's/G_GNUC_END_IGNORE_DEPRECATIONS/ /g'
+  - fi
+
 build_scripts:
   - if [ ${DISTRO_NAME} == "debian" ];then
   -     curl -Ls -o debian.sh https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/debian.sh

--- a/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
+++ b/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
@@ -121,7 +121,7 @@ get_n_toolbars (EggEditableToolbar *etoolbar)
 
 static GtkWidget *
 get_dock_nth (EggEditableToolbar *etoolbar,
-	      int                 position)
+              int                 position)
 {
   GList *l;
   GtkWidget *result;
@@ -135,7 +135,7 @@ get_dock_nth (EggEditableToolbar *etoolbar,
 
 static GtkWidget *
 get_toolbar_nth (EggEditableToolbar *etoolbar,
-		 int                 position)
+                 int                 position)
 {
   GList *l;
   GtkWidget *dock;
@@ -153,7 +153,7 @@ get_toolbar_nth (EggEditableToolbar *etoolbar,
 
 static GtkAction *
 find_action (EggEditableToolbar *etoolbar,
-	     const char         *name)
+             const char         *name)
 {
   GList *l;
   GtkAction *action = NULL;
@@ -168,7 +168,7 @@ find_action (EggEditableToolbar *etoolbar,
 
       tmp = gtk_action_group_get_action (GTK_ACTION_GROUP (l->data), name);
       if (tmp)
-	action = tmp;
+        action = tmp;
     }
 
   return action;
@@ -176,8 +176,8 @@ find_action (EggEditableToolbar *etoolbar,
 
 static void
 drag_data_delete_cb (GtkWidget          *widget,
-		     GdkDragContext     *context,
-		     EggEditableToolbar *etoolbar)
+                     GdkDragContext     *context,
+                     EggEditableToolbar *etoolbar)
 {
   int pos, toolbar_pos;
   GtkWidget *parent;
@@ -188,17 +188,17 @@ drag_data_delete_cb (GtkWidget          *widget,
 
   parent = gtk_widget_get_parent (widget);
   pos = gtk_toolbar_get_item_index (GTK_TOOLBAR (parent),
-				    GTK_TOOL_ITEM (widget));
+                                    GTK_TOOL_ITEM (widget));
   toolbar_pos = get_toolbar_position (etoolbar, parent);
 
   egg_toolbars_model_remove_item (etoolbar->priv->model,
-				  toolbar_pos, pos);
+                                  toolbar_pos, pos);
 }
 
 static void
 drag_begin_cb (GtkWidget          *widget,
-	       GdkDragContext     *context,
-	       EggEditableToolbar *etoolbar)
+               GdkDragContext     *context,
+               EggEditableToolbar *etoolbar)
 {
   GtkAction *action;
   gint flags;
@@ -210,20 +210,20 @@ drag_begin_cb (GtkWidget          *widget,
   if (action == NULL) return;
 
   flags = egg_toolbars_model_get_name_flags (etoolbar->priv->model,
-					     gtk_action_get_name (action));
+                                             gtk_action_get_name (action));
   if (!(flags & EGG_TB_MODEL_NAME_INFINITE))
     {
       flags &= ~EGG_TB_MODEL_NAME_USED;
       egg_toolbars_model_set_name_flags (etoolbar->priv->model,
-					 gtk_action_get_name (action),
-					 flags);
+                                         gtk_action_get_name (action),
+                                         flags);
     }
 }
 
 static void
 drag_end_cb (GtkWidget          *widget,
-	     GdkDragContext     *context,
-	     EggEditableToolbar *etoolbar)
+             GdkDragContext     *context,
+             EggEditableToolbar *etoolbar)
 {
   GtkAction *action;
   gint flags;
@@ -237,24 +237,24 @@ drag_end_cb (GtkWidget          *widget,
       if (action == NULL) return;
 
       flags = egg_toolbars_model_get_name_flags (etoolbar->priv->model,
-						 gtk_action_get_name (action));
+                                                 gtk_action_get_name (action));
       if (!(flags & EGG_TB_MODEL_NAME_INFINITE))
         {
-	  flags |= EGG_TB_MODEL_NAME_USED;
-	  egg_toolbars_model_set_name_flags (etoolbar->priv->model,
-					     gtk_action_get_name (action),
-					     flags);
-	}
+          flags |= EGG_TB_MODEL_NAME_USED;
+          egg_toolbars_model_set_name_flags (etoolbar->priv->model,
+                                             gtk_action_get_name (action),
+                                             flags);
+        }
     }
 }
 
 static void
 drag_data_get_cb (GtkWidget          *widget,
-		  GdkDragContext     *context,
-		  GtkSelectionData   *selection_data,
-		  guint               info,
-		  guint32             time,
-		  EggEditableToolbar *etoolbar)
+                  GdkDragContext     *context,
+                  GtkSelectionData   *selection_data,
+                  guint               info,
+                  guint32             time,
+                  EggEditableToolbar *etoolbar)
 {
   EggToolbarsModel *model;
   const char *name;
@@ -319,10 +319,10 @@ remove_item_cb (GtkAction          *action,
 
   toolbar_pos = get_toolbar_position (etoolbar, parent);
   pos = gtk_toolbar_get_item_index (GTK_TOOLBAR (parent),
-				    GTK_TOOL_ITEM (toolitem));
+                                    GTK_TOOL_ITEM (toolitem));
 
   egg_toolbars_model_remove_item (etoolbar->priv->model,
-			          toolbar_pos, pos);
+                                  toolbar_pos, pos);
 
   if (egg_toolbars_model_n_items (etoolbar->priv->model, toolbar_pos) == 0)
     {
@@ -332,7 +332,7 @@ remove_item_cb (GtkAction          *action,
 
 static void
 remove_toolbar_cb (GtkAction          *action,
-		   EggEditableToolbar *etoolbar)
+                   EggEditableToolbar *etoolbar)
 {
   GtkWidget *selected = egg_editable_toolbar_get_selected (etoolbar);
   GtkWidget *toolbar = gtk_widget_get_ancestor (selected, GTK_TYPE_TOOLBAR);
@@ -344,7 +344,7 @@ remove_toolbar_cb (GtkAction          *action,
 
 static void
 popup_context_deactivate (GtkMenuShell *menu,
-			  EggEditableToolbar *etoolbar)
+                          EggEditableToolbar *etoolbar)
 {
   egg_editable_toolbar_set_selected (etoolbar, NULL);
   g_object_notify (G_OBJECT (etoolbar), "selected");
@@ -352,9 +352,9 @@ popup_context_deactivate (GtkMenuShell *menu,
 
 static void
 popup_context_menu_cb (GtkWidget          *toolbar,
-                       gint		   x,
-                       gint		   y,
-                       gint                button_number,
+                       gint               x,
+                       gint               y,
+                       gint               button_number,
                        EggEditableToolbar *etoolbar)
 {
   if (etoolbar->priv->popup_path != NULL)
@@ -365,12 +365,12 @@ popup_context_menu_cb (GtkWidget          *toolbar,
       g_object_notify (G_OBJECT (etoolbar), "selected");
 
       menu = GTK_MENU (gtk_ui_manager_get_widget (etoolbar->priv->manager,
-						  etoolbar->priv->popup_path));
+                                                  etoolbar->priv->popup_path));
       g_return_if_fail (menu != NULL);
       gtk_menu_popup_at_pointer (menu, NULL);
       g_signal_connect_object (menu, "selection-done",
-			       G_CALLBACK (popup_context_deactivate),
-			       etoolbar, 0);
+                               G_CALLBACK (popup_context_deactivate),
+                               etoolbar, 0);
     }
 }
 
@@ -399,12 +399,12 @@ button_press_event_cb (GtkWidget *widget,
       g_object_notify (G_OBJECT (etoolbar), "selected");
 
       menu = GTK_MENU (gtk_ui_manager_get_widget (etoolbar->priv->manager,
-						  etoolbar->priv->popup_path));
+                                                  etoolbar->priv->popup_path));
       g_return_val_if_fail (menu != NULL, FALSE);
       gtk_menu_popup_at_pointer (menu, (const GdkEvent*) event);
       g_signal_connect_object (menu, "selection-done",
-			       G_CALLBACK (popup_context_deactivate),
-			       etoolbar, 0);
+                               G_CALLBACK (popup_context_deactivate),
+                               etoolbar, 0);
 
       return TRUE;
     }
@@ -427,8 +427,8 @@ configure_item_sensitivity (GtkToolItem *item, EggEditableToolbar *etoolbar)
     }
 
   gtk_tool_item_set_use_drag_window (item,
-				     (etoolbar->priv->edit_mode > 0) ||
-				     GTK_IS_SEPARATOR_TOOL_ITEM (item));
+                                     (etoolbar->priv->edit_mode > 0) ||
+                                     GTK_IS_SEPARATOR_TOOL_ITEM (item));
 
 }
 
@@ -451,7 +451,7 @@ configure_item_window_drag (GtkToolItem        *item,
 
 static void
 configure_item_cursor (GtkToolItem *item,
-		       EggEditableToolbar *etoolbar)
+                       EggEditableToolbar *etoolbar)
 {
   EggEditableToolbarPrivate *priv = etoolbar->priv;
   GtkWidget *widget = GTK_WIDGET (item);
@@ -462,13 +462,13 @@ configure_item_cursor (GtkToolItem *item,
       if (priv->edit_mode > 0)
         {
           GdkCursor *cursor;
-	  GdkScreen *screen;
+          GdkScreen *screen;
           GdkPixbuf *pixbuf = NULL;
 
-	  screen = gtk_widget_get_screen (GTK_WIDGET (etoolbar));
+          screen = gtk_widget_get_screen (GTK_WIDGET (etoolbar));
 
           cursor = gdk_cursor_new_for_display (gdk_screen_get_display (screen),
-					       GDK_HAND2);
+                                               GDK_HAND2);
           gdk_window_set_cursor (window, cursor);
           g_object_unref (cursor);
 
@@ -516,7 +516,7 @@ configure_item_cursor (GtkToolItem *item,
               else if (stock_id)
                 {
                   pixbuf = gtk_widget_render_icon_pixbuf (widget, stock_id,
-	                                                  GTK_ICON_SIZE_LARGE_TOOLBAR);
+                                                          GTK_ICON_SIZE_LARGE_TOOLBAR);
                 }
               g_free (icon_name);
               g_free (stock_id);
@@ -558,31 +558,31 @@ connect_widget_signals (GtkWidget *proxy, EggEditableToolbar *etoolbar)
   if (GTK_IS_CONTAINER (proxy))
     {
        gtk_container_forall (GTK_CONTAINER (proxy),
-			     (GtkCallback) connect_widget_signals,
-			     (gpointer) etoolbar);
+                             (GtkCallback) connect_widget_signals,
+                             (gpointer) etoolbar);
     }
 
   if (GTK_IS_TOOL_ITEM (proxy))
     {
       g_signal_connect_object (proxy, "drag_begin",
-			       G_CALLBACK (drag_begin_cb),
-			       etoolbar, 0);
+                               G_CALLBACK (drag_begin_cb),
+                               etoolbar, 0);
       g_signal_connect_object (proxy, "drag_end",
-			       G_CALLBACK (drag_end_cb),
-			       etoolbar, 0);
+                               G_CALLBACK (drag_end_cb),
+                               etoolbar, 0);
       g_signal_connect_object (proxy, "drag_data_get",
-			       G_CALLBACK (drag_data_get_cb),
-			       etoolbar, 0);
+                               G_CALLBACK (drag_data_get_cb),
+                               etoolbar, 0);
       g_signal_connect_object (proxy, "drag_data_delete",
-			       G_CALLBACK (drag_data_delete_cb),
-			       etoolbar, 0);
+                               G_CALLBACK (drag_data_delete_cb),
+                               etoolbar, 0);
     }
 
   if (GTK_IS_BUTTON (proxy) || GTK_IS_TOOL_ITEM (proxy))
     {
       g_signal_connect_object (proxy, "button-press-event",
-			       G_CALLBACK (button_press_event_cb),
-			       etoolbar, 0);
+                               G_CALLBACK (button_press_event_cb),
+                               etoolbar, 0);
     }
 }
 
@@ -607,7 +607,7 @@ action_sensitive_cb (GtkAction   *action,
 
 static GtkToolItem *
 create_item_from_action (EggEditableToolbar *etoolbar,
-			 const char *name)
+                         const char *name)
 {
   GtkToolItem *item;
 
@@ -689,8 +689,8 @@ toolbar_drag_data_received_cb (GtkToolbar         *toolbar,
       ipos = gtk_toolbar_get_drop_index (toolbar, x, y);
       name = egg_toolbars_model_get_name (etoolbar->priv->model, type, data, FALSE);
       if (name != NULL)
-	{
-	  used = ((egg_toolbars_model_get_name_flags (etoolbar->priv->model, name) & EGG_TB_MODEL_NAME_USED) != 0);
+        {
+          used = ((egg_toolbars_model_get_name_flags (etoolbar->priv->model, name) & EGG_TB_MODEL_NAME_USED) != 0);
         }
     }
 
@@ -723,12 +723,12 @@ toolbar_drag_data_received_cb (GtkToolbar         *toolbar,
           gint tpos = get_toolbar_position (etoolbar, GTK_WIDGET (toolbar));
           egg_toolbars_model_add_item (etoolbar->priv->model, tpos, ipos, name);
           gtk_drag_finish (context, TRUE,
-			   gdk_drag_context_get_selected_action (context) == GDK_ACTION_MOVE, time);
+                           gdk_drag_context_get_selected_action (context) == GDK_ACTION_MOVE, time);
         }
       else
         {
           gtk_drag_finish (context, FALSE,
-			   gdk_drag_context_get_selected_action (context) == GDK_ACTION_MOVE, time);
+                           gdk_drag_context_get_selected_action (context) == GDK_ACTION_MOVE, time);
         }
     }
 
@@ -737,11 +737,11 @@ toolbar_drag_data_received_cb (GtkToolbar         *toolbar,
 
 static gboolean
 toolbar_drag_drop_cb (GtkToolbar         *toolbar,
-		      GdkDragContext     *context,
-		      gint                x,
-		      gint                y,
-		      guint               time,
-		      EggEditableToolbar *etoolbar)
+                      GdkDragContext     *context,
+                      gint                x,
+                      gint                y,
+                      guint               time,
+                      EggEditableToolbar *etoolbar)
 {
   GdkAtom target;
 
@@ -757,11 +757,11 @@ toolbar_drag_drop_cb (GtkToolbar         *toolbar,
 
 static gboolean
 toolbar_drag_motion_cb (GtkToolbar         *toolbar,
-		        GdkDragContext     *context,
-		        gint                x,
-		        gint                y,
-		        guint               time,
-		        EggEditableToolbar *etoolbar)
+                        GdkDragContext     *context,
+                        gint                x,
+                        gint                y,
+                        guint               time,
+                        EggEditableToolbar *etoolbar)
 {
   GdkAtom target = gtk_drag_dest_find_target (GTK_WIDGET (toolbar), context, NULL);
   if (target == GDK_NONE)
@@ -794,9 +794,9 @@ toolbar_drag_motion_cb (GtkToolbar         *toolbar,
 
 static void
 toolbar_drag_leave_cb (GtkToolbar         *toolbar,
-		       GdkDragContext     *context,
-		       guint               time,
-		       EggEditableToolbar *etoolbar)
+                       GdkDragContext     *context,
+                       guint               time,
+                       EggEditableToolbar *etoolbar)
 {
   gtk_toolbar_set_drop_highlight_item (toolbar, NULL, 0);
 
@@ -818,8 +818,8 @@ configure_drag_dest (EggEditableToolbar *etoolbar,
 
   /* Make every toolbar able to receive drag-drops. */
   gtk_drag_dest_set (GTK_WIDGET (toolbar), 0,
-		     dest_drag_types, G_N_ELEMENTS (dest_drag_types),
-		     GDK_ACTION_MOVE | GDK_ACTION_COPY);
+                     dest_drag_types, G_N_ELEMENTS (dest_drag_types),
+                     GDK_ACTION_MOVE | GDK_ACTION_COPY);
 
   /* Add any specialist drag-drop abilities. */
   targets = gtk_drag_dest_get_target_list (GTK_WIDGET (toolbar));
@@ -835,7 +835,7 @@ configure_drag_dest (EggEditableToolbar *etoolbar,
 
 static void
 toggled_visibility_cb (GtkToggleAction *action,
-		       EggEditableToolbar *etoolbar)
+                       EggEditableToolbar *etoolbar)
 {
   EggEditableToolbarPrivate *priv = etoolbar->priv;
   GtkWidget *dock;
@@ -866,12 +866,12 @@ toggled_visibility_cb (GtkToggleAction *action,
 
       if (visible)
         {
-	  flags &= ~(EGG_TB_MODEL_HIDDEN);
-	}
+          flags &= ~(EGG_TB_MODEL_HIDDEN);
+        }
       else
-	{
-	  flags |=  (EGG_TB_MODEL_HIDDEN);
-	}
+        {
+          flags |=  (EGG_TB_MODEL_HIDDEN);
+        }
 
       egg_toolbars_model_set_flags (priv->model, i, flags);
     }
@@ -936,34 +936,34 @@ toolbar_visibility_refresh (EggEditableToolbar *etoolbar)
           g_object_get_property (G_OBJECT (action), "label", &value);
           name = g_value_get_string (&value);
           if (name == NULL)
-	    {
-		g_value_unset (&value);
-		continue;
-	    }
-	  k += g_utf8_strlen (name, -1) + 2;
-	  if (j > 0)
-	    {
-	      g_string_append (string, ", ");
-	      if (j > 1 && k > 25)
-		{
-		  g_value_unset (&value);
-		  break;
-		}
-	    }
-	  g_string_append (string, name);
-	  g_value_unset (&value);
-	}
+            {
+                g_value_unset (&value);
+                continue;
+            }
+          k += g_utf8_strlen (name, -1) + 2;
+          if (j > 0)
+            {
+              g_string_append (string, ", ");
+              if (j > 1 && k > 25)
+                {
+                  g_value_unset (&value);
+                  break;
+                }
+            }
+          g_string_append (string, name);
+          g_value_unset (&value);
+        }
       if (j < n_items)
         {
-	  g_string_append (string, " ...");
+          g_string_append (string, " ...");
         }
 
       tmp = g_string_free (string, FALSE);
       for (j = 0, k = 0; tmp[j]; j++)
       {
-	if (tmp[j] == '_') continue;
-	tmp[k] = tmp[j];
-	k++;
+        if (tmp[j] == '_') continue;
+        tmp[k] = tmp[j];
+        k++;
       }
       tmp[k] = 0;
       /* Translaters: This string is for a toggle to display a toolbar.
@@ -980,21 +980,21 @@ toolbar_visibility_refresh (EggEditableToolbar *etoolbar)
 
       if (i >= priv->visibility_actions->len)
         {
-	  action = gtk_toggle_action_new (action_name, action_label, NULL, NULL);
-	  g_ptr_array_add (priv->visibility_actions, action);
-	  g_signal_connect_object (action, "toggled",
-				   G_CALLBACK (toggled_visibility_cb),
-				   etoolbar, 0);
-	  gtk_action_group_add_action (priv->actions, GTK_ACTION (action));
-	}
+          action = gtk_toggle_action_new (action_name, action_label, NULL, NULL);
+          g_ptr_array_add (priv->visibility_actions, action);
+          g_signal_connect_object (action, "toggled",
+                                   G_CALLBACK (toggled_visibility_cb),
+                                   etoolbar, 0);
+          gtk_action_group_add_action (priv->actions, GTK_ACTION (action));
+        }
       else
         {
-	  action = g_ptr_array_index (priv->visibility_actions, i);
-	  g_object_set (action, "label", action_label, NULL);
+          action = g_ptr_array_index (priv->visibility_actions, i);
+          g_object_set (action, "label", action_label, NULL);
         }
 
       gtk_action_set_visible (GTK_ACTION (action), (egg_toolbars_model_get_flags (priv->model, i)
-						    & EGG_TB_MODEL_NOT_REMOVABLE) == 0);
+                                                    & EGG_TB_MODEL_NOT_REMOVABLE) == 0);
       gtk_action_set_sensitive (GTK_ACTION (action), showing);
 
       visible = gtk_widget_get_visible (get_dock_nth (etoolbar, i));
@@ -1021,10 +1021,10 @@ toolbar_visibility_refresh (EggEditableToolbar *etoolbar)
 
       for (list = priv->visibility_paths; list != NULL; list = g_list_next (list))
         {
-	  gtk_ui_manager_add_ui (priv->manager, priv->visibility_id,
-				 (const char *)list->data, action_name, action_name,
-				 GTK_UI_MANAGER_MENUITEM, FALSE);
-	}
+          gtk_ui_manager_add_ui (priv->manager, priv->visibility_id,
+                                 (const char *)list->data, action_name, action_name,
+                                 GTK_UI_MANAGER_MENUITEM, FALSE);
+        }
 
       g_free (action_label);
     }
@@ -1053,16 +1053,16 @@ create_dock (EggEditableToolbar *etoolbar)
   gtk_box_pack_start (GTK_BOX (hbox), toolbar, TRUE, TRUE, 0);
 
   g_signal_connect (toolbar, "drag_drop",
-		    G_CALLBACK (toolbar_drag_drop_cb), etoolbar);
+                    G_CALLBACK (toolbar_drag_drop_cb), etoolbar);
   g_signal_connect (toolbar, "drag_motion",
-		    G_CALLBACK (toolbar_drag_motion_cb), etoolbar);
+                    G_CALLBACK (toolbar_drag_motion_cb), etoolbar);
   g_signal_connect (toolbar, "drag_leave",
-		    G_CALLBACK (toolbar_drag_leave_cb), etoolbar);
+                    G_CALLBACK (toolbar_drag_leave_cb), etoolbar);
 
   g_signal_connect (toolbar, "drag_data_received",
-		    G_CALLBACK (toolbar_drag_data_received_cb), etoolbar);
+                    G_CALLBACK (toolbar_drag_data_received_cb), etoolbar);
   g_signal_connect (toolbar, "popup_context_menu",
-		    G_CALLBACK (popup_context_menu_cb), etoolbar);
+                    G_CALLBACK (popup_context_menu_cb), etoolbar);
 
   configure_drag_dest (etoolbar, GTK_TOOLBAR (toolbar));
 
@@ -1074,7 +1074,7 @@ set_fixed_style (EggEditableToolbar *t, GtkToolbarStyle style)
 {
   g_return_if_fail (GTK_IS_TOOLBAR (t->priv->fixed_toolbar));
   gtk_toolbar_set_style (GTK_TOOLBAR (t->priv->fixed_toolbar),
-  			 style == GTK_TOOLBAR_ICONS ? GTK_TOOLBAR_BOTH_HORIZ : style);
+                         style == GTK_TOOLBAR_ICONS ? GTK_TOOLBAR_BOTH_HORIZ : style);
 }
 
 static void
@@ -1086,8 +1086,8 @@ unset_fixed_style (EggEditableToolbar *t)
 
 static void
 toolbar_changed_cb (EggToolbarsModel   *model,
-	            int                 position,
-	            EggEditableToolbar *etoolbar)
+                    int                 position,
+                    EggEditableToolbar *etoolbar)
 {
   GtkWidget *toolbar;
   EggTbModelFlags flags;
@@ -1168,8 +1168,8 @@ update_fixed (EggEditableToolbar *etoolbar)
 
 static void
 toolbar_added_cb (EggToolbarsModel   *model,
-	          int                 position,
-	          EggEditableToolbar *etoolbar)
+                  int                 position,
+                  EggEditableToolbar *etoolbar)
 {
   GtkWidget *dock;
 
@@ -1192,8 +1192,8 @@ toolbar_added_cb (EggToolbarsModel   *model,
 
 static void
 toolbar_removed_cb (EggToolbarsModel   *model,
-	            int                 position,
-	            EggEditableToolbar *etoolbar)
+                    int                 position,
+                    EggEditableToolbar *etoolbar)
 {
   GtkWidget *dock;
 
@@ -1212,9 +1212,9 @@ toolbar_removed_cb (EggToolbarsModel   *model,
 
 static void
 item_added_cb (EggToolbarsModel   *model,
-	       int                 tpos,
-	       int                 ipos,
-	       EggEditableToolbar *etoolbar)
+               int                 tpos,
+               int                 ipos,
+               EggEditableToolbar *etoolbar)
 {
   GtkWidget *dock;
   GtkWidget *toolbar;
@@ -1241,9 +1241,9 @@ item_added_cb (EggToolbarsModel   *model,
 
 static void
 item_removed_cb (EggToolbarsModel   *model,
-	         int                 toolbar_position,
-	         int                 position,
-	         EggEditableToolbar *etoolbar)
+                 int                 toolbar_position,
+                 int                 position,
+                 EggEditableToolbar *etoolbar)
 {
   EggEditableToolbarPrivate *priv = etoolbar->priv;
 
@@ -1252,7 +1252,7 @@ item_removed_cb (EggToolbarsModel   *model,
 
   toolbar = get_toolbar_nth (etoolbar, toolbar_position);
   item = GTK_WIDGET (gtk_toolbar_get_nth_item
-	(GTK_TOOLBAR (toolbar), position));
+        (GTK_TOOLBAR (toolbar), position));
   g_return_if_fail (item != NULL);
 
   if (item == priv->selected)
@@ -1294,10 +1294,10 @@ egg_editable_toolbar_build (EggEditableToolbar *etoolbar)
           item = create_item_from_position (etoolbar, i, l);
           if (item)
             {
-	      gtk_toolbar_insert (GTK_TOOLBAR (toolbar), item, l);
+              gtk_toolbar_insert (GTK_TOOLBAR (toolbar), item, l);
 
               connect_widget_signals (GTK_WIDGET (item), etoolbar);
-	      configure_item_tooltip (item);
+              configure_item_tooltip (item);
               configure_item_sensitivity (item, etoolbar);
             }
           else
@@ -1361,7 +1361,7 @@ egg_editable_toolbar_deconstruct (EggEditableToolbar *toolbar)
 
 void
 egg_editable_toolbar_set_model (EggEditableToolbar *etoolbar,
-				EggToolbarsModel   *model)
+                                EggToolbarsModel   *model)
 {
   EggEditableToolbarPrivate *priv = etoolbar->priv;
 
@@ -1382,15 +1382,15 @@ egg_editable_toolbar_set_model (EggEditableToolbar *etoolbar,
   toolbar_visibility_refresh (etoolbar);
 
   g_signal_connect (model, "item_added",
-		    G_CALLBACK (item_added_cb), etoolbar);
+                    G_CALLBACK (item_added_cb), etoolbar);
   g_signal_connect (model, "item_removed",
-		    G_CALLBACK (item_removed_cb), etoolbar);
+                    G_CALLBACK (item_removed_cb), etoolbar);
   g_signal_connect (model, "toolbar_added",
-		    G_CALLBACK (toolbar_added_cb), etoolbar);
+                    G_CALLBACK (toolbar_added_cb), etoolbar);
   g_signal_connect (model, "toolbar_removed",
-		    G_CALLBACK (toolbar_removed_cb), etoolbar);
+                    G_CALLBACK (toolbar_removed_cb), etoolbar);
   g_signal_connect (model, "toolbar_changed",
-		    G_CALLBACK (toolbar_changed_cb), etoolbar);
+                    G_CALLBACK (toolbar_changed_cb), etoolbar);
 }
 
 static void
@@ -1405,7 +1405,7 @@ egg_editable_toolbar_init (EggEditableToolbar *etoolbar)
   priv->save_hidden = TRUE;
 
   g_signal_connect (etoolbar, "notify::visible",
-		    G_CALLBACK (toolbar_visibility_refresh), NULL);
+                    G_CALLBACK (toolbar_visibility_refresh), NULL);
 }
 
 static void
@@ -1439,9 +1439,9 @@ egg_editable_toolbar_dispose (GObject *object)
     {
       if (priv->visibility_id)
         {
-	  gtk_ui_manager_remove_ui (priv->manager, priv->visibility_id);
-	  priv->visibility_id = 0;
-	}
+          gtk_ui_manager_remove_ui (priv->manager, priv->visibility_id);
+          priv->visibility_id = 0;
+        }
 
       g_object_unref (priv->manager);
       priv->manager = NULL;
@@ -1459,7 +1459,7 @@ egg_editable_toolbar_dispose (GObject *object)
 
 static void
 egg_editable_toolbar_set_ui_manager (EggEditableToolbar *etoolbar,
-				     GtkUIManager       *manager)
+                                     GtkUIManager       *manager)
 {
   static const GtkActionEntry actions[] = {
     { "MoveToolItem", STOCK_DRAG_MODE, N_("_Move on Toolbar"), NULL,
@@ -1475,7 +1475,7 @@ egg_editable_toolbar_set_ui_manager (EggEditableToolbar *etoolbar,
   etoolbar->priv->actions = gtk_action_group_new ("ToolbarActions");
   gtk_action_group_set_translation_domain (etoolbar->priv->actions, GETTEXT_PACKAGE);
   gtk_action_group_add_actions (etoolbar->priv->actions, actions,
-		 		G_N_ELEMENTS (actions), etoolbar);
+                                G_N_ELEMENTS (actions), etoolbar);
   gtk_ui_manager_insert_action_group (manager, etoolbar->priv->actions, -1);
   g_object_unref (etoolbar->priv->actions);
 
@@ -1495,7 +1495,7 @@ GtkWidget * egg_editable_toolbar_get_selected (EggEditableToolbar   *etoolbar)
 
 void
 egg_editable_toolbar_set_selected (EggEditableToolbar *etoolbar,
-				   GtkWidget          *widget)
+                                   GtkWidget          *widget)
 {
   GtkWidget *toolbar, *toolitem;
   gboolean editable;
@@ -1522,7 +1522,7 @@ egg_editable_toolbar_set_selected (EggEditableToolbar *etoolbar,
 
 static void
 set_edit_mode (EggEditableToolbar *etoolbar,
-	       gboolean mode)
+               gboolean mode)
 {
   EggEditableToolbarPrivate *priv = etoolbar->priv;
   int i, l, n_items;
@@ -1571,9 +1571,9 @@ set_edit_mode (EggEditableToolbar *etoolbar,
 
 static void
 egg_editable_toolbar_set_property (GObject      *object,
-				   guint         prop_id,
-				   const GValue *value,
-				   GParamSpec   *pspec)
+                                   guint         prop_id,
+                                   const GValue *value,
+                                   GParamSpec   *pspec)
 {
   EggEditableToolbar *etoolbar = EGG_EDITABLE_TOOLBAR (object);
 
@@ -1602,9 +1602,9 @@ egg_editable_toolbar_set_property (GObject      *object,
 
 static void
 egg_editable_toolbar_get_property (GObject    *object,
-				   guint       prop_id,
-				   GValue     *value,
-				   GParamSpec *pspec)
+                                   guint       prop_id,
+                                   GValue     *value,
+                                   GParamSpec *pspec)
 {
   EggEditableToolbar *etoolbar = EGG_EDITABLE_TOOLBAR (object);
 
@@ -1639,49 +1639,49 @@ egg_editable_toolbar_class_init (EggEditableToolbarClass *klass)
 
   egg_editable_toolbar_signals[ACTION_REQUEST] =
     g_signal_new ("action_request",
-		  G_OBJECT_CLASS_TYPE (object_class),
-		  G_SIGNAL_RUN_LAST,
-		  G_STRUCT_OFFSET (EggEditableToolbarClass, action_request),
-		  NULL, NULL, g_cclosure_marshal_VOID__STRING,
-		  G_TYPE_NONE, 1, G_TYPE_STRING);
+                  G_OBJECT_CLASS_TYPE (object_class),
+                  G_SIGNAL_RUN_LAST,
+                  G_STRUCT_OFFSET (EggEditableToolbarClass, action_request),
+                  NULL, NULL, g_cclosure_marshal_VOID__STRING,
+                  G_TYPE_NONE, 1, G_TYPE_STRING);
 
   g_object_class_install_property (object_class,
-				   PROP_UI_MANAGER,
-				   g_param_spec_object ("ui-manager",
-							"UI-Mmanager",
-							"UI Manager",
-							GTK_TYPE_UI_MANAGER,
-							G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
+                                   PROP_UI_MANAGER,
+                                   g_param_spec_object ("ui-manager",
+                                                        "UI-Mmanager",
+                                                        "UI Manager",
+                                                        GTK_TYPE_UI_MANAGER,
+                                                        G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property (object_class,
-				   PROP_TOOLBARS_MODEL,
-				   g_param_spec_object ("model",
-							"Model",
-							"Toolbars Model",
-							EGG_TYPE_TOOLBARS_MODEL,
-							G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
+                                   PROP_TOOLBARS_MODEL,
+                                   g_param_spec_object ("model",
+                                                        "Model",
+                                                        "Toolbars Model",
+                                                        EGG_TYPE_TOOLBARS_MODEL,
+                                                        G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
   g_object_class_install_property (object_class,
-				   PROP_SELECTED,
-				   g_param_spec_object ("selected",
-							"Selected",
-							"Selected toolitem",
-							GTK_TYPE_TOOL_ITEM,
-							G_PARAM_READABLE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
+                                   PROP_SELECTED,
+                                   g_param_spec_object ("selected",
+                                                        "Selected",
+                                                        "Selected toolitem",
+                                                        GTK_TYPE_TOOL_ITEM,
+                                                        G_PARAM_READABLE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
   g_object_class_install_property (object_class,
-				   PROP_POPUP_PATH,
-				   g_param_spec_string ("popup-path",
-							"popup-path",
-							"popup-path",
-							NULL,
-							G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
+                                   PROP_POPUP_PATH,
+                                   g_param_spec_string ("popup-path",
+                                                        "popup-path",
+                                                        "popup-path",
+                                                        NULL,
+                                                        G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
   g_object_class_install_property (object_class,
-				   PROP_EDIT_MODE,
-				   g_param_spec_boolean ("edit-mode",
-							 "Edit-Mode",
-							 "Edit Mode",
-							 FALSE,
-							 G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
+                                   PROP_EDIT_MODE,
+                                   g_param_spec_boolean ("edit-mode",
+                                                         "Edit-Mode",
+                                                         "Edit Mode",
+                                                         FALSE,
+                                                         G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 
   g_type_class_add_private (object_class, sizeof (EggEditableToolbarPrivate));
 }
@@ -1698,14 +1698,14 @@ egg_editable_toolbar_new (GtkUIManager *manager,
 
 GtkWidget *
 egg_editable_toolbar_new_with_model (GtkUIManager *manager,
- 				     EggToolbarsModel *model,
+                                     EggToolbarsModel *model,
                                      const char *popup_path)
 {
   return GTK_WIDGET (g_object_new (EGG_TYPE_EDITABLE_TOOLBAR,
                                    "ui-manager", manager,
                                    "model", model,
                                    "popup-path", popup_path,
-				   NULL));
+                                   NULL));
 }
 
 gboolean
@@ -1718,7 +1718,7 @@ egg_editable_toolbar_get_edit_mode (EggEditableToolbar *etoolbar)
 
 void
 egg_editable_toolbar_set_edit_mode (EggEditableToolbar *etoolbar,
-				    gboolean mode)
+                                    gboolean mode)
 {
   set_edit_mode (etoolbar, mode);
   g_object_notify (G_OBJECT (etoolbar), "edit-mode");
@@ -1726,15 +1726,15 @@ egg_editable_toolbar_set_edit_mode (EggEditableToolbar *etoolbar,
 
 void
 egg_editable_toolbar_add_visibility (EggEditableToolbar *etoolbar,
-				     const char *path)
+                                     const char *path)
 {
   etoolbar->priv->visibility_paths = g_list_prepend
-	  (etoolbar->priv->visibility_paths, g_strdup (path));
+          (etoolbar->priv->visibility_paths, g_strdup (path));
 }
 
 void
 egg_editable_toolbar_show (EggEditableToolbar *etoolbar,
-			   const char *name)
+                           const char *name)
 {
   EggEditableToolbarPrivate *priv = etoolbar->priv;
   EggToolbarsModel *model = priv->model;
@@ -1755,7 +1755,7 @@ egg_editable_toolbar_show (EggEditableToolbar *etoolbar,
 
 void
 egg_editable_toolbar_hide (EggEditableToolbar *etoolbar,
-			   const char *name)
+                           const char *name)
 {
   EggEditableToolbarPrivate *priv = etoolbar->priv;
   EggToolbarsModel *model = priv->model;
@@ -1776,7 +1776,7 @@ egg_editable_toolbar_hide (EggEditableToolbar *etoolbar,
 
 void
 egg_editable_toolbar_set_fixed (EggEditableToolbar *etoolbar,
-				GtkToolbar *toolbar)
+                                GtkToolbar *toolbar)
 {
   EggEditableToolbarPrivate *priv = etoolbar->priv;
 
@@ -1870,7 +1870,7 @@ _egg_editable_toolbar_new_separator_image (void)
   GtkWidget *image = gtk_image_new ();
   update_separator_image (GTK_IMAGE (image));
   g_signal_connect (G_OBJECT (image), "style_set",
-		    G_CALLBACK (style_set_cb), GTK_IMAGE (image));
+                    G_CALLBACK (style_set_cb), GTK_IMAGE (image));
 
   return image;
 }

--- a/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
+++ b/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
@@ -166,7 +166,9 @@ find_action (EggEditableToolbar *etoolbar,
     {
       GtkAction *tmp;
 
+      G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
       tmp = gtk_action_group_get_action (GTK_ACTION_GROUP (l->data), name);
+      G_GNUC_END_IGNORE_DEPRECATIONS;
       if (tmp)
         action = tmp;
     }
@@ -205,6 +207,7 @@ drag_begin_cb (GtkWidget          *widget,
 
   gtk_widget_hide (widget);
 
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
   action = gtk_activatable_get_related_action (GTK_ACTIVATABLE (widget));
 
   if (action == NULL) return;
@@ -218,6 +221,7 @@ drag_begin_cb (GtkWidget          *widget,
                                          gtk_action_get_name (action),
                                          flags);
     }
+  G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static void
@@ -232,6 +236,7 @@ drag_end_cb (GtkWidget          *widget,
     {
       gtk_widget_show (widget);
 
+      G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
       action = gtk_activatable_get_related_action (GTK_ACTIVATABLE (widget));
 
       if (action == NULL) return;
@@ -245,6 +250,7 @@ drag_end_cb (GtkWidget          *widget,
                                              gtk_action_get_name (action),
                                              flags);
         }
+      G_GNUC_END_IGNORE_DEPRECATIONS;
     }
 }
 
@@ -543,7 +549,9 @@ configure_item_tooltip (GtkToolItem *item)
 {
   GtkAction *action;
 
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
   action = gtk_activatable_get_related_action (GTK_ACTIVATABLE (item));
+  G_GNUC_END_IGNORE_DEPRECATIONS;
 
   if (action != NULL)
     {
@@ -623,6 +631,7 @@ create_item_from_action (EggEditableToolbar *etoolbar,
       GtkAction *action = find_action (etoolbar, name);
       if (action == NULL) return NULL;
 
+      G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
       item = GTK_TOOL_ITEM (gtk_action_create_tool_item (action));
 
       /* Normally done on-demand by the GtkUIManager, but no
@@ -630,6 +639,7 @@ create_item_from_action (EggEditableToolbar *etoolbar,
        */
       gtk_action_set_accel_group
         (action, gtk_ui_manager_get_accel_group(etoolbar->priv->manager));
+      G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 
       g_signal_connect_object (action, "notify::sensitive",
                                G_CALLBACK (action_sensitive_cb), item, 0);

--- a/cut-n-paste/toolbar-editor/egg-editable-toolbar.h
+++ b/cut-n-paste/toolbar-editor/egg-editable-toolbar.h
@@ -52,42 +52,42 @@ struct _EggEditableToolbarClass
   GtkBoxClass parent_class;
 
   void (* action_request) (EggEditableToolbar *etoolbar,
-			   const char *action_name);
+                           const char *action_name);
 };
 
-GType               egg_editable_toolbar_get_type        (void);
-GtkWidget	   *egg_editable_toolbar_new		 (GtkUIManager         *manager,
-							  const char           *visibility_path);
-GtkWidget	   *egg_editable_toolbar_new_with_model	 (GtkUIManager         *manager,
-							  EggToolbarsModel     *model,
-							  const char           *visibility_path);
-void		    egg_editable_toolbar_set_model       (EggEditableToolbar   *etoolbar,
-							  EggToolbarsModel     *model);
-EggToolbarsModel   *egg_editable_toolbar_get_model       (EggEditableToolbar   *etoolbar);
-GtkUIManager       *egg_editable_toolbar_get_manager     (EggEditableToolbar   *etoolbar);
-void		    egg_editable_toolbar_set_edit_mode	 (EggEditableToolbar   *etoolbar,
-							  gboolean              mode);
-gboolean	    egg_editable_toolbar_get_edit_mode	 (EggEditableToolbar   *etoolbar);
-void		    egg_editable_toolbar_show		 (EggEditableToolbar   *etoolbar,
-							  const char           *name);
-void		    egg_editable_toolbar_hide		 (EggEditableToolbar   *etoolbar,
-							  const char           *name);
-void		    egg_editable_toolbar_set_fixed       (EggEditableToolbar   *etoolbar,
-							  GtkToolbar           *fixed_toolbar);
+GType             egg_editable_toolbar_get_type        (void);
+GtkWidget         *egg_editable_toolbar_new            (GtkUIManager         *manager,
+                                                        const char           *visibility_path);
+GtkWidget         *egg_editable_toolbar_new_with_model (GtkUIManager         *manager,
+                                                        EggToolbarsModel     *model,
+                                                        const char           *visibility_path);
+void              egg_editable_toolbar_set_model       (EggEditableToolbar   *etoolbar,
+                                                        EggToolbarsModel     *model);
+EggToolbarsModel  *egg_editable_toolbar_get_model      (EggEditableToolbar   *etoolbar);
+GtkUIManager      *egg_editable_toolbar_get_manager    (EggEditableToolbar   *etoolbar);
+void              egg_editable_toolbar_set_edit_mode   (EggEditableToolbar   *etoolbar,
+                                                        gboolean              mode);
+gboolean          egg_editable_toolbar_get_edit_mode   (EggEditableToolbar   *etoolbar);
+void              egg_editable_toolbar_show            (EggEditableToolbar   *etoolbar,
+                                                        const char           *name);
+void              egg_editable_toolbar_hide            (EggEditableToolbar   *etoolbar,
+                                                        const char           *name);
+void              egg_editable_toolbar_set_fixed       (EggEditableToolbar   *etoolbar,
+                                                        GtkToolbar           *fixed_toolbar);
 
-GtkWidget *         egg_editable_toolbar_get_selected    (EggEditableToolbar   *etoolbar);
-void                egg_editable_toolbar_set_selected    (EggEditableToolbar   *etoolbar,
-							  GtkWidget            *widget);
+GtkWidget *       egg_editable_toolbar_get_selected    (EggEditableToolbar   *etoolbar);
+void              egg_editable_toolbar_set_selected    (EggEditableToolbar   *etoolbar,
+                                                        GtkWidget            *widget);
 
-void              egg_editable_toolbar_add_visibility    (EggEditableToolbar   *etoolbar,
-							  const char           *path);
+void              egg_editable_toolbar_add_visibility  (EggEditableToolbar   *etoolbar,
+                                                        const char           *path);
 void              egg_editable_toolbar_set_primary_class (EggEditableToolbar *etoolbar,
                                                           gboolean            set,
                                                           const gchar        *path);
 
 /* Private Functions */
 
-GtkWidget 	   *_egg_editable_toolbar_new_separator_image (void);
+GtkWidget         *_egg_editable_toolbar_new_separator_image (void);
 
 G_END_DECLS
 

--- a/cut-n-paste/toolbar-editor/egg-toolbar-editor.c
+++ b/cut-n-paste/toolbar-editor/egg-toolbar-editor.c
@@ -90,7 +90,7 @@ compare_items (gconstpointer a,
 
 static GtkAction *
 find_action (EggToolbarEditor *t,
-	     const char       *name)
+             const char       *name)
 {
   GList *l;
   GtkAction *action = NULL;
@@ -106,7 +106,7 @@ find_action (EggToolbarEditor *t,
 
       tmp = gtk_action_group_get_action (GTK_ACTION_GROUP (l->data), name);
       if (tmp)
-	action = tmp;
+        action = tmp;
     }
 
   return action;
@@ -114,7 +114,7 @@ find_action (EggToolbarEditor *t,
 
 static void
 egg_toolbar_editor_set_ui_manager (EggToolbarEditor *t,
-				   GtkUIManager     *manager)
+                                   GtkUIManager     *manager)
 {
   g_return_if_fail (GTK_IS_UI_MANAGER (manager));
 
@@ -132,8 +132,8 @@ item_added_or_removed_cb (EggToolbarsModel   *model,
 
 static void
 toolbar_removed_cb (EggToolbarsModel   *model,
-	            int                 position,
-	            EggToolbarEditor   *editor)
+                    int                 position,
+                    EggToolbarEditor   *editor)
 {
   update_editor_sheet (editor);
 }
@@ -152,19 +152,19 @@ egg_toolbar_editor_disconnect_model (EggToolbarEditor *t)
 
       if (handler != 0)
         {
-	  if (g_signal_handler_is_connected (model, handler))
-	    {
-	      g_signal_handler_disconnect (model, handler);
-	    }
+          if (g_signal_handler_is_connected (model, handler))
+            {
+              g_signal_handler_disconnect (model, handler);
+            }
 
-	  priv->sig_handlers[i] = 0;
+          priv->sig_handlers[i] = 0;
         }
     }
 }
 
 void
 egg_toolbar_editor_set_model (EggToolbarEditor *t,
-			      EggToolbarsModel *model)
+                              EggToolbarsModel *model)
 {
   EggToolbarEditorPrivate *priv;
 
@@ -187,20 +187,20 @@ egg_toolbar_editor_set_model (EggToolbarEditor *t,
 
   priv->sig_handlers[SIGNAL_HANDLER_ITEM_ADDED] =
     g_signal_connect_object (model, "item_added",
-			     G_CALLBACK (item_added_or_removed_cb), t, 0);
+                             G_CALLBACK (item_added_or_removed_cb), t, 0);
   priv->sig_handlers[SIGNAL_HANDLER_ITEM_REMOVED] =
     g_signal_connect_object (model, "item_removed",
-			     G_CALLBACK (item_added_or_removed_cb), t, 0);
+                             G_CALLBACK (item_added_or_removed_cb), t, 0);
   priv->sig_handlers[SIGNAL_HANDLER_TOOLBAR_REMOVED] =
     g_signal_connect_object (model, "toolbar_removed",
-			     G_CALLBACK (toolbar_removed_cb), t, 0);
+                             G_CALLBACK (toolbar_removed_cb), t, 0);
 }
 
 static void
 egg_toolbar_editor_set_property (GObject      *object,
-				 guint         prop_id,
-				 const GValue *value,
-				 GParamSpec   *pspec)
+                                 guint         prop_id,
+                                 const GValue *value,
+                                 GParamSpec   *pspec)
 {
   EggToolbarEditor *t = EGG_TOOLBAR_EDITOR (object);
 
@@ -217,9 +217,9 @@ egg_toolbar_editor_set_property (GObject      *object,
 
 static void
 egg_toolbar_editor_get_property (GObject    *object,
-				 guint       prop_id,
-				 GValue     *value,
-				 GParamSpec *pspec)
+                                 guint       prop_id,
+                                 GValue     *value,
+                                 GParamSpec *pspec)
 {
   EggToolbarEditor *t = EGG_TOOLBAR_EDITOR (object);
 
@@ -244,21 +244,21 @@ egg_toolbar_editor_class_init (EggToolbarEditorClass *klass)
   object_class->get_property = egg_toolbar_editor_get_property;
 
   g_object_class_install_property (object_class,
-				   PROP_UI_MANAGER,
-				   g_param_spec_object ("ui-manager",
-							"UI-Manager",
-							"UI Manager",
-							GTK_TYPE_UI_MANAGER,
-							G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB |
-							G_PARAM_CONSTRUCT_ONLY));
+                                   PROP_UI_MANAGER,
+                                   g_param_spec_object ("ui-manager",
+                                                        "UI-Manager",
+                                                        "UI Manager",
+                                                        GTK_TYPE_UI_MANAGER,
+                                                        G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB |
+                                                        G_PARAM_CONSTRUCT_ONLY));
  g_object_class_install_property (object_class,
-				  PROP_TOOLBARS_MODEL,
-				  g_param_spec_object ("model",
-						       "Model",
-						       "Toolbars Model",
-						       EGG_TYPE_TOOLBARS_MODEL,
-						       G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB |
-						       G_PARAM_CONSTRUCT));
+                                  PROP_TOOLBARS_MODEL,
+                                  g_param_spec_object ("model",
+                                                       "Model",
+                                                       "Toolbars Model",
+                                                       EGG_TYPE_TOOLBARS_MODEL,
+                                                       G_PARAM_READWRITE | G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB |
+                                                       G_PARAM_CONSTRUCT));
 
   GtkWidgetClass *widget_class  = GTK_WIDGET_CLASS (klass);
   gtk_widget_class_set_css_name (widget_class, "EggToolbarEditor");
@@ -290,35 +290,35 @@ egg_toolbar_editor_finalize (GObject *object)
 
 GtkWidget *
 egg_toolbar_editor_new (GtkUIManager *manager,
-			EggToolbarsModel *model)
+                        EggToolbarsModel *model)
 {
   return GTK_WIDGET (g_object_new (EGG_TYPE_TOOLBAR_EDITOR,
-				   "ui-manager", manager,
-				   "model", model,
-				   NULL));
+                                   "ui-manager", manager,
+                                   "model", model,
+                                   NULL));
 }
 
 static void
 drag_begin_cb (GtkWidget          *widget,
-	       GdkDragContext     *context)
+               GdkDragContext     *context)
 {
   gtk_widget_hide (widget);
 }
 
 static void
 drag_end_cb (GtkWidget          *widget,
-	     GdkDragContext     *context)
+             GdkDragContext     *context)
 {
   gtk_widget_show (widget);
 }
 
 static void
 drag_data_get_cb (GtkWidget          *widget,
-		  GdkDragContext     *context,
-		  GtkSelectionData   *selection_data,
-		  guint               info,
-		  guint32             time,
-		  EggToolbarEditor   *editor)
+                  GdkDragContext     *context,
+                  GtkSelectionData   *selection_data,
+                  guint               info,
+                  guint32             time,
+                  EggToolbarEditor   *editor)
 {
   const char *target;
 
@@ -326,8 +326,8 @@ drag_data_get_cb (GtkWidget          *widget,
   g_return_if_fail (target != NULL);
 
   gtk_selection_data_set (selection_data,
-			  gtk_selection_data_get_target (selection_data), 8,
-			  (const guchar *) target, strlen (target));
+                          gtk_selection_data_get_target (selection_data), 8,
+                          (const guchar *) target, strlen (target));
 }
 
 static gchar *
@@ -343,12 +343,12 @@ elide_underscores (const gchar *original)
   for (p = original; *p; p++)
     {
       if (!last_underscore && *p == '_')
-	last_underscore = TRUE;
+        last_underscore = TRUE;
       else
-	{
-	  last_underscore = FALSE;
-	  *q++ = *p;
-	}
+        {
+          last_underscore = FALSE;
+          *q++ = *p;
+        }
     }
 
   *q = '\0';
@@ -365,7 +365,7 @@ set_drag_cursor (GtkWidget *widget)
   screen = gtk_widget_get_screen (widget);
 
   cursor = gdk_cursor_new_for_display (gdk_screen_get_display (screen),
-				       GDK_HAND2);
+                                       GDK_HAND2);
   gdk_window_set_cursor (gtk_widget_get_window (widget), cursor);
   g_object_unref (cursor);
 }
@@ -385,7 +385,7 @@ event_box_realize_cb (GtkWidget *widget, GtkImage *icon)
 
       gtk_image_get_stock (icon, &stock_id, NULL);
       pixbuf = gtk_widget_render_icon_pixbuf (widget, stock_id,
-	                                      GTK_ICON_SIZE_LARGE_TOOLBAR);
+                                              GTK_ICON_SIZE_LARGE_TOOLBAR);
       gtk_drag_source_set_icon_pixbuf (widget, pixbuf);
       g_object_unref (pixbuf);
     }
@@ -402,10 +402,10 @@ event_box_realize_cb (GtkWidget *widget, GtkImage *icon)
       icon_theme = gtk_icon_theme_get_for_screen (screen);
 
       if (!gtk_icon_size_lookup (GTK_ICON_SIZE_LARGE_TOOLBAR,
-					             &width, &height))
+                                 &width, &height))
         {
-	  width = height = 24;
-	}
+          width = height = 24;
+        }
 
       pixbuf = gtk_icon_theme_load_icon (icon_theme, icon_name,
                                          MIN (width, height), 0, NULL);
@@ -425,9 +425,9 @@ event_box_realize_cb (GtkWidget *widget, GtkImage *icon)
 
 static GtkWidget *
 editor_create_item (EggToolbarEditor *editor,
-		    GtkImage	     *icon,
-		    const char       *label_text,
-		    GdkDragAction     action)
+                    GtkImage         *icon,
+                    const char       *label_text,
+                    GdkDragAction    action)
 {
   GtkWidget *event_box;
   GtkWidget *vbox;
@@ -438,19 +438,19 @@ editor_create_item (EggToolbarEditor *editor,
   gtk_event_box_set_visible_window (GTK_EVENT_BOX (event_box), FALSE);
   gtk_widget_show (event_box);
   gtk_drag_source_set (event_box,
-		       GDK_BUTTON1_MASK,
-		       source_drag_types, G_N_ELEMENTS (source_drag_types), action);
+                       GDK_BUTTON1_MASK,
+                       source_drag_types, G_N_ELEMENTS (source_drag_types), action);
   g_signal_connect (event_box, "drag_data_get",
-		    G_CALLBACK (drag_data_get_cb), editor);
+                    G_CALLBACK (drag_data_get_cb), editor);
   g_signal_connect_after (event_box, "realize",
-		          G_CALLBACK (event_box_realize_cb), icon);
+                          G_CALLBACK (event_box_realize_cb), icon);
 
   if (action == GDK_ACTION_MOVE)
     {
       g_signal_connect (event_box, "drag_begin",
-		        G_CALLBACK (drag_begin_cb), NULL);
+                        G_CALLBACK (drag_begin_cb), NULL);
       g_signal_connect (event_box, "drag_end",
-		        G_CALLBACK (drag_end_cb), NULL);
+                        G_CALLBACK (drag_end_cb), NULL);
     }
 
   vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
@@ -501,13 +501,13 @@ editor_create_item_from_name (EggToolbarEditor *editor,
       g_object_get (action,
                     "icon-name", &icon_name,
                     "stock-id", &stock_id,
-		    "short-label", &short_label,
-		    NULL);
+                    "short-label", &short_label,
+                    NULL);
 
       /* This is a workaround to catch named icons. */
       if (icon_name)
         icon = gtk_image_new_from_icon_name (icon_name,
-	                                     GTK_ICON_SIZE_LARGE_TOOLBAR);
+                                             GTK_ICON_SIZE_LARGE_TOOLBAR);
       else
         icon = gtk_image_new_from_icon_name (stock_id ? stock_id : "gtk-dnd",
                                              GTK_ICON_SIZE_LARGE_TOOLBAR);
@@ -588,7 +588,7 @@ update_editor_sheet (EggToolbarEditor *editor)
   gtk_grid_set_row_spacing (GTK_GRID (grid), 24);
   gtk_widget_show (grid);
   gtk_drag_dest_set (grid, GTK_DEST_DEFAULT_ALL,
-		     dest_drag_types, G_N_ELEMENTS (dest_drag_types),
+                     dest_drag_types, G_N_ELEMENTS (dest_drag_types),
                      GDK_ACTION_MOVE | GDK_ACTION_COPY);
 
   /* Build two lists of items (one for copying, one for moving). */

--- a/cut-n-paste/toolbar-editor/egg-toolbar-editor.c
+++ b/cut-n-paste/toolbar-editor/egg-toolbar-editor.c
@@ -104,7 +104,9 @@ find_action (EggToolbarEditor *t,
     {
       GtkAction *tmp;
 
+      G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
       tmp = gtk_action_group_get_action (GTK_ACTION_GROUP (l->data), name);
+      G_GNUC_END_IGNORE_DEPRECATIONS;
       if (tmp)
         action = tmp;
     }

--- a/cut-n-paste/toolbar-editor/egg-toolbar-editor.h
+++ b/cut-n-paste/toolbar-editor/egg-toolbar-editor.h
@@ -52,11 +52,11 @@ struct EggToolbarEditorClass
 };
 
 
-GType             egg_toolbar_editor_get_type     (void);
-GtkWidget        *egg_toolbar_editor_new          (GtkUIManager *manager,
-						   EggToolbarsModel *model);
-void		  egg_toolbar_editor_set_model	  (EggToolbarEditor *t,
-						   EggToolbarsModel *model);
+GType            egg_toolbar_editor_get_type     (void);
+GtkWidget        *egg_toolbar_editor_new         (GtkUIManager *manager,
+                                                  EggToolbarsModel *model);
+void             egg_toolbar_editor_set_model    (EggToolbarEditor *t,
+                                                  EggToolbarsModel *model);
 
 G_END_DECLS
 

--- a/cut-n-paste/zoom-control/ephy-zoom-action.c
+++ b/cut-n-paste/zoom-control/ephy-zoom-action.c
@@ -58,7 +58,9 @@ enum
 
 static guint signals[LAST_SIGNAL] = { 0 };
 
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 G_DEFINE_TYPE_WITH_PRIVATE (EphyZoomAction, ephy_zoom_action, GTK_TYPE_ACTION)
+G_GNUC_END_IGNORE_DEPRECATIONS;
 
 static void
 zoom_to_level_cb (EphyZoomControl *control,
@@ -106,8 +108,9 @@ connect_proxy (GtkAction *action, GtkWidget *proxy)
 		g_signal_connect (proxy, "zoom_to_level",
 				  G_CALLBACK (zoom_to_level_cb), action);
 	}
-
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	GTK_ACTION_CLASS (ephy_zoom_action_parent_class)->connect_proxy (action, proxy);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static void
@@ -164,7 +167,9 @@ create_menu_item (GtkAction *action)
 
 	gtk_widget_show (menu);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         menu_item = GTK_ACTION_CLASS (ephy_zoom_action_parent_class)->create_menu_item (action);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	gtk_menu_item_set_submenu (GTK_MENU_ITEM (menu_item), menu);
 
@@ -225,7 +230,9 @@ static void
 ephy_zoom_action_class_init (EphyZoomActionClass *class)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (class);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	GtkActionClass *action_class = GTK_ACTION_CLASS (class);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	object_class->set_property = ephy_zoom_action_set_property;
 	object_class->get_property = ephy_zoom_action_get_property;

--- a/libmisc/ev-page-action.c
+++ b/libmisc/ev-page-action.c
@@ -49,7 +49,9 @@ enum
 
 static guint signals[N_SIGNALS] = {0, };
 
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 G_DEFINE_TYPE (EvPageAction, ev_page_action, GTK_TYPE_ACTION)
+G_GNUC_END_IGNORE_DEPRECATIONS;
 
 #define EV_PAGE_ACTION_GET_PRIVATE(object)(G_TYPE_INSTANCE_GET_PRIVATE ((object), EV_TYPE_PAGE_ACTION, EvPageActionPrivate))
 
@@ -96,7 +98,9 @@ connect_proxy (GtkAction *action, GtkWidget *proxy)
 					 proxy, 0);
 	}
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	GTK_ACTION_CLASS (ev_page_action_parent_class)->connect_proxy (action, proxy);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static void
@@ -187,7 +191,9 @@ ev_page_action_grab_focus (EvPageAction *page_action)
 {
 	GSList *proxies;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	proxies = gtk_action_get_proxies (GTK_ACTION (page_action));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	for (; proxies != NULL; proxies = proxies->next) {
 		EvPageActionWidget *proxy;
 
@@ -208,7 +214,9 @@ static void
 ev_page_action_class_init (EvPageActionClass *class)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (class);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	GtkActionClass *action_class = GTK_ACTION_CLASS (class);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	object_class->dispose = ev_page_action_dispose;
 	object_class->set_property = ev_page_action_set_property;

--- a/previewer/ev-previewer-window.c
+++ b/previewer/ev-previewer-window.c
@@ -146,6 +146,7 @@ ev_previewer_window_zoom_reset (GtkAction         *action,
 	ev_view_zoom_reset (window->view);
 }
 
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 static void
 ev_previewer_window_zoom_fit_page (GtkToggleAction   *action,
 				   EvPreviewerWindow *window)
@@ -163,6 +164,7 @@ ev_previewer_window_zoom_fit_width (GtkToggleAction   *action,
 					   gtk_toggle_action_get_active (action) ?
 					   EV_SIZING_FIT_WIDTH : EV_SIZING_FREE);
 }
+G_GNUC_END_IGNORE_DEPRECATIONS;
 
 static void
 ev_previewer_window_action_page_activated (GtkAction         *action,
@@ -179,8 +181,10 @@ ev_previewer_window_focus_page_selector (GtkAction         *action,
 {
 	GtkAction *page_action;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	page_action = gtk_action_group_get_action (window->action_group,
 						   "PageSelector");
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	ev_page_action_grab_focus (EV_PAGE_ACTION (page_action));
 }
 
@@ -345,8 +349,10 @@ view_focus_changed (GtkWidget         *widget,
 		    GdkEventFocus     *event,
 		    EvPreviewerWindow *window)
 {
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	if (window->accels_group)
 		gtk_action_group_set_sensitive (window->accels_group, event->in);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	return FALSE;
 }
@@ -359,22 +365,26 @@ view_sizing_mode_changed (EvDocumentModel   *model,
 	EvSizingMode sizing_mode = ev_document_model_get_sizing_mode (model);
 	GtkAction   *action;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->action_group, "ViewFitPage");
 	g_signal_handlers_block_by_func (action,
 					 G_CALLBACK (ev_previewer_window_zoom_fit_page),
 					 window);
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action),
 				      sizing_mode == EV_SIZING_FIT_PAGE);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_signal_handlers_unblock_by_func (action,
 					   G_CALLBACK (ev_previewer_window_zoom_fit_page),
 					   window);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->action_group, "ViewFitWidth");
 	g_signal_handlers_block_by_func (action,
 					 G_CALLBACK (ev_previewer_window_zoom_fit_width),
 					 window);
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action),
 				      sizing_mode == EV_SIZING_FIT_WIDTH);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_signal_handlers_unblock_by_func (action,
 					   G_CALLBACK (ev_previewer_window_zoom_fit_width),
 					   window);
@@ -392,8 +402,10 @@ ev_previewer_window_set_document (EvPreviewerWindow *window,
 	g_signal_connect (model, "notify::sizing-mode",
 			  G_CALLBACK (view_sizing_mode_changed),
 			  window);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_group_set_sensitive (window->action_group, TRUE);
 	gtk_action_group_set_sensitive (window->accels_group, TRUE);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static void
@@ -403,8 +415,10 @@ ev_previewer_window_connect_action_accelerators (EvPreviewerWindow *window)
 
 	gtk_ui_manager_ensure_update (window->ui_manager);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	actions = gtk_action_group_list_actions (window->action_group);
 	g_list_foreach (actions, (GFunc)gtk_action_connect_accelerator, NULL);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_list_free (actions);
 }
 
@@ -522,6 +536,7 @@ ev_previewer_window_constructor (GType                  type,
 				  G_CALLBACK (ev_previewer_window_set_document),
 				  window);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	window->action_group = gtk_action_group_new ("PreviewerActions");
 	gtk_action_group_set_translation_domain (window->action_group, NULL);
 	gtk_action_group_add_actions (window->action_group, action_entries,
@@ -531,6 +546,7 @@ ev_previewer_window_constructor (GType                  type,
 					     G_N_ELEMENTS (toggle_action_entries),
 					     window);
 	gtk_action_group_set_sensitive (window->action_group, FALSE);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	action = g_object_new (EV_TYPE_PAGE_ACTION,
 			       "name", "PageSelector",
@@ -543,6 +559,7 @@ ev_previewer_window_constructor (GType                  type,
 	g_signal_connect (action, "activate_link",
 			  G_CALLBACK (ev_previewer_window_action_page_activated),
 			  window);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_group_add_action (window->action_group, action);
 	g_object_unref (action);
 
@@ -551,6 +568,7 @@ ev_previewer_window_constructor (GType                  type,
 				      G_N_ELEMENTS (accel_entries),
 				      window);
 	gtk_action_group_set_sensitive (window->accels_group, FALSE);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	window->ui_manager = gtk_ui_manager_new ();
 	gtk_ui_manager_insert_action_group (window->ui_manager,

--- a/shell/ev-bookmark-action.c
+++ b/shell/ev-bookmark-action.c
@@ -37,7 +37,9 @@ struct _EvBookmarkActionClass {
         GtkActionClass base_class;
 };
 
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 G_DEFINE_TYPE (EvBookmarkAction, ev_bookmark_action, GTK_TYPE_ACTION)
+G_GNUC_END_IGNORE_DEPRECATIONS;
 
 static void
 ev_bookmark_action_init (EvBookmarkAction *action)
@@ -86,11 +88,13 @@ ev_bookmark_action_new (EvBookmark *bookmark)
         g_return_val_if_fail (bookmark->title != NULL, NULL);
 
         name = g_strdup_printf ("EvBookmark%u", bookmark->page);
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         action = GTK_ACTION (g_object_new (EV_TYPE_BOOKMARK_ACTION,
                                            "name", name,
                                            "label", bookmark->title,
                                            "page", bookmark->page,
                                            NULL));
+        G_GNUC_END_IGNORE_DEPRECATIONS;
         g_free (name);
 
         return action;

--- a/shell/ev-navigation-action.c
+++ b/shell/ev-navigation-action.c
@@ -43,7 +43,9 @@ struct _EvNavigationActionPrivate
 static void ev_navigation_action_init       (EvNavigationAction *action);
 static void ev_navigation_action_class_init (EvNavigationActionClass *class);
 
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 G_DEFINE_TYPE (EvNavigationAction, ev_navigation_action, GTK_TYPE_ACTION)
+G_GNUC_END_IGNORE_DEPRECATIONS;
 
 #define MAX_LABEL_LENGTH 48
 
@@ -55,8 +57,10 @@ ev_navigation_action_history_changed (EvHistory *history,
 {
 	EvNavigationAction *action = EV_NAVIGATION_ACTION (data);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_set_sensitive (GTK_ACTION (action),
 				  ev_history_get_n_links (history) > 0);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 void
@@ -170,7 +174,9 @@ connect_proxy (GtkAction *action, GtkWidget *proxy)
 				  G_CALLBACK (menu_activated_cb), action);
 	}
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	GTK_ACTION_CLASS (ev_navigation_action_parent_class)->connect_proxy (action, proxy);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static GtkWidget *
@@ -192,7 +198,9 @@ create_menu_item (GtkAction *action)
 
 	menu = build_menu (EV_NAVIGATION_ACTION (action));
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         menu_item = GTK_ACTION_CLASS (ev_navigation_action_parent_class)->create_menu_item (action);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	gtk_menu_item_set_submenu (GTK_MENU_ITEM (menu_item), menu);
 
@@ -225,7 +233,9 @@ static void
 ev_navigation_action_class_init (EvNavigationActionClass *class)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (class);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	GtkActionClass *action_class = GTK_ACTION_CLASS (class);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	object_class->finalize = ev_navigation_action_finalize;
 

--- a/shell/ev-open-recent-action.c
+++ b/shell/ev-open-recent-action.c
@@ -35,7 +35,9 @@ static void ev_open_recent_action_class_init (EvOpenRecentActionClass *class);
 
 static guint action_signals[N_SIGNALS] = { 0 };
 
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 G_DEFINE_TYPE (EvOpenRecentAction, ev_open_recent_action, GTK_TYPE_ACTION)
+G_GNUC_END_IGNORE_DEPRECATIONS;
 
 static void
 recent_chooser_item_activated (GtkRecentChooser *chooser,
@@ -84,7 +86,9 @@ static void
 ev_open_recent_action_class_init (EvOpenRecentActionClass *class)
 {
 	GObjectClass   *object_class = G_OBJECT_CLASS (class);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	GtkActionClass *action_class = GTK_ACTION_CLASS (class);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	action_class->toolbar_item_type = GTK_TYPE_MENU_TOOL_BUTTON;
 	action_class->create_tool_item = ev_open_recent_action_create_tool_item;

--- a/shell/ev-sidebar-bookmarks.c
+++ b/shell/ev-sidebar-bookmarks.c
@@ -493,11 +493,13 @@ ev_sidebar_bookmarks_init (EvSidebarBookmarks *sidebar_bookmarks)
         gtk_widget_show (GTK_WIDGET (sidebar_bookmarks));
 
         /* Popup menu */
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         priv->action_group = gtk_action_group_new ("BookmarsPopupActions");
         gtk_action_group_set_translation_domain (priv->action_group, NULL);
         gtk_action_group_add_actions (priv->action_group, popup_entries,
                                       G_N_ELEMENTS (popup_entries),
                                       sidebar_bookmarks);
+        G_GNUC_END_IGNORE_DEPRECATIONS;
         priv->ui_manager = gtk_ui_manager_new ();
         gtk_ui_manager_insert_action_group (priv->ui_manager,
                                             priv->action_group, 0);

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -413,9 +413,11 @@ ev_window_set_action_sensitive (EvWindow   *ev_window,
 		    	        const char *name,
 		  	        gboolean    sensitive)
 {
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	GtkAction *action = gtk_action_group_get_action (ev_window->priv->action_group,
 							 name);
 	gtk_action_set_sensitive (action, sensitive);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 
@@ -635,8 +637,10 @@ ev_window_update_actions (EvWindow *ev_window)
 		float      zoom;
 		float      real_zoom;
 
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		action = gtk_action_group_get_action (ev_window->priv->action_group,
 						      ZOOM_CONTROL_ACTION);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 
 		real_zoom = ev_document_model_get_scale (ev_window->priv->model);
 		real_zoom *= 72.0 / get_screen_dpi (ev_window);
@@ -721,6 +725,7 @@ update_sizing_buttons (EvWindow *window)
 			break;
 	}
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (action_group, "ViewFitPage");
 	g_signal_handlers_block_by_func
 		(action, G_CALLBACK (ev_window_cmd_view_fit_page), window);
@@ -737,6 +742,8 @@ update_sizing_buttons (EvWindow *window)
 
 	action = gtk_action_group_get_action (window->priv->action_group,
 					      ZOOM_CONTROL_ACTION);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
+
 	if (fit_page) {
 		ephy_zoom_action_set_zoom_level (EPHY_ZOOM_ACTION (action),
 						 EPHY_ZOOM_FIT_PAGE);
@@ -755,11 +762,13 @@ update_chrome_actions (EvWindow *window)
 	GtkActionGroup *action_group = priv->action_group;
 	GtkAction *action;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action= gtk_action_group_get_action (action_group, "ViewToolbar");
 	g_signal_handlers_block_by_func
 		(action, G_CALLBACK (ev_window_view_toolbar_cb), window);
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action),
 				      (priv->chrome & EV_CHROME_TOOLBAR) != 0);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_signal_handlers_unblock_by_func
 		(action, G_CALLBACK (ev_window_view_toolbar_cb), window);
 }
@@ -1684,8 +1693,10 @@ ev_window_setup_document (EvWindow *ev_window)
 	if (ev_window->priv->history)
 		g_object_unref (ev_window->priv->history);
 	ev_window->priv->history = ev_history_new ();
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (ev_window->priv->action_group, NAVIGATION_ACTION);
-        ev_navigation_action_set_history (EV_NAVIGATION_ACTION (action), ev_window->priv->history);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
+	ev_navigation_action_set_history (EV_NAVIGATION_ACTION (action), ev_window->priv->history);
 
 	if (ev_window->priv->properties) {
 		ev_properties_dialog_set_document (EV_PROPERTIES_DIALOG (ev_window->priv->properties),
@@ -2914,7 +2925,9 @@ ev_window_setup_recent (EvWindow *ev_window)
 						    ev_window->priv->recent_action_group);
 		g_object_unref (ev_window->priv->recent_action_group);
 	}
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	ev_window->priv->recent_action_group = gtk_action_group_new ("RecentFilesActions");
+	G_GNUC_END_IGNORE_DEPRECATIONS;
         g_signal_connect (ev_window->priv->recent_action_group, "connect-proxy",
                           G_CALLBACK (ev_window_recent_action_connect_proxy_cb), NULL);
 
@@ -2949,13 +2962,14 @@ ev_window_setup_recent (EvWindow *ev_window)
                         icon = g_content_type_get_icon (content_type);
                         g_free (content_type);
                 }
-
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		action = g_object_new (GTK_TYPE_ACTION,
 				       "name", action_name,
 				       "label", label,
                                        "gicon", icon,
                                        "always-show-image", TRUE,
 				       NULL);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 
 		g_object_set_data_full (G_OBJECT (action),
 					"gtk-recent-info",
@@ -2966,8 +2980,10 @@ ev_window_setup_recent (EvWindow *ev_window)
 				  G_CALLBACK (ev_window_cmd_recent_file_activate),
 				  (gpointer) ev_window);
 
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		gtk_action_group_add_action (ev_window->priv->recent_action_group,
 					     action);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 		g_object_unref (action);
 
 		gtk_ui_manager_add_ui (ev_window->priv->ui_manager,
@@ -4011,8 +4027,10 @@ ev_window_cmd_focus_page_selector (GtkAction *act, EvWindow *window)
 	ev_window_set_action_sensitive (window, "ViewToolbar", FALSE);
 	update_chrome_visibility (window);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->priv->action_group,
 				     	      PAGE_SELECTOR_ACTION);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	ev_page_action_grab_focus (EV_PAGE_ACTION (action));
 }
 
@@ -4042,7 +4060,9 @@ ev_window_cmd_continuous (GtkAction *action, EvWindow *ev_window)
 	gboolean continuous;
 
 	ev_window_stop_presentation (ev_window, TRUE);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	continuous = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	ev_document_model_set_continuous (ev_window->priv->model, continuous);
 }
 
@@ -4052,7 +4072,9 @@ ev_window_cmd_dual (GtkAction *action, EvWindow *ev_window)
 	gboolean dual_page;
 
 	ev_window_stop_presentation (ev_window, TRUE);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	dual_page = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	ev_document_model_set_dual_page (ev_window->priv->model, dual_page);
 }
 
@@ -4061,7 +4083,9 @@ ev_window_cmd_dual_odd_pages_left (GtkAction *action, EvWindow *ev_window)
 {
 	gboolean dual_page_odd_left;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	dual_page_odd_left = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	ev_document_model_set_dual_page_odd_pages_left (ev_window->priv->model,
 							dual_page_odd_left);
 }
@@ -4071,11 +4095,13 @@ ev_window_cmd_view_fit_page (GtkAction *action, EvWindow *ev_window)
 {
 	ev_window_stop_presentation (ev_window, TRUE);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	if (gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action))) {
 		ev_document_model_set_sizing_mode (ev_window->priv->model, EV_SIZING_FIT_PAGE);
 	} else {
 		ev_document_model_set_sizing_mode (ev_window->priv->model, EV_SIZING_FREE);
 	}
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	ev_window_update_actions (ev_window);
 }
 
@@ -4090,11 +4116,13 @@ ev_window_cmd_view_fit_width (GtkAction *action, EvWindow *ev_window)
 {
 	ev_window_stop_presentation (ev_window, TRUE);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	if (gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action))) {
 		ev_document_model_set_sizing_mode (ev_window->priv->model, EV_SIZING_FIT_WIDTH);
 	} else {
 		ev_document_model_set_sizing_mode (ev_window->priv->model, EV_SIZING_FREE);
 	}
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	ev_window_update_actions (ev_window);
 }
 
@@ -4209,11 +4237,13 @@ ev_window_update_fullscreen_action (EvWindow *window)
 {
 	GtkAction *action;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->priv->action_group, "ViewFullscreen");
 	g_signal_handlers_block_by_func
 		(action, G_CALLBACK (ev_window_cmd_view_fullscreen), window);
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action),
 				      ev_document_model_get_fullscreen (window->priv->model));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_signal_handlers_unblock_by_func
 		(action, G_CALLBACK (ev_window_cmd_view_fullscreen), window);
 }
@@ -4322,7 +4352,9 @@ ev_window_cmd_view_fullscreen (GtkAction *action, EvWindow *window)
 {
 	gboolean fullscreen;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	fullscreen = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	if (fullscreen) {
 		ev_window_run_fullscreen (window);
 	} else {
@@ -4364,11 +4396,13 @@ ev_window_update_presentation_action (EvWindow *window)
 {
 	GtkAction *action;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->priv->action_group, "ViewPresentation");
 	g_signal_handlers_block_by_func
 		(action, G_CALLBACK (ev_window_cmd_view_presentation), window);
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action),
 				      EV_WINDOW_IS_PRESENTATION (window));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_signal_handlers_unblock_by_func
 		(action, G_CALLBACK (ev_window_cmd_view_presentation), window);
 }
@@ -4500,7 +4534,9 @@ ev_window_cmd_view_presentation (GtkAction *action, EvWindow *window)
 {
 	gboolean presentation;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	presentation = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	if (presentation) {
 		ev_window_run_presentation (window);
 	}
@@ -4557,8 +4593,10 @@ ev_window_update_max_min_scale (EvWindow *window)
 	height = (rotation == 0 || rotation == 180) ? min_height : min_width;
 	max_scale = sqrt ((page_cache_mb * 1024 * 1024) / (width * dpi * 4 * height * dpi));
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->priv->action_group,
 					      ZOOM_CONTROL_ACTION);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	ephy_zoom_action_set_max_zoom_level (EPHY_ZOOM_ACTION (action), max_scale * dpi);
 
 	ev_document_model_set_min_scale (window->priv->model, MIN_SCALE * dpi);
@@ -4949,7 +4987,9 @@ ev_window_setup_bookmarks (EvWindow *window)
 						    window->priv->bookmarks_action_group);
 		g_object_unref (window->priv->bookmarks_action_group);
 	}
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	window->priv->bookmarks_action_group = gtk_action_group_new ("BookmarksActions");
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	gtk_ui_manager_insert_action_group (window->priv->ui_manager,
 					    window->priv->bookmarks_action_group, -1);
 
@@ -4959,19 +4999,25 @@ ev_window_setup_bookmarks (EvWindow *window)
 	for (l = items; l && l->data; l = g_list_next (l)) {
 		EvBookmark *bm = (EvBookmark *)l->data;
 		GtkAction  *action;
+		const gchar *action_name;
+		const gchar *action_label;
 
 		action = ev_bookmark_action_new (bm);
 		g_signal_connect (action, "activate",
 				  G_CALLBACK (ev_window_cmd_bookmark_activate),
 				  window);
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		gtk_action_group_add_action (window->priv->bookmarks_action_group,
 					     action);
 
+		action_name = gtk_action_get_name (action);
+		action_label = gtk_action_get_label (action);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 		gtk_ui_manager_add_ui (window->priv->ui_manager,
 				       window->priv->bookmarks_ui_id,
 				       "/MainMenu/BookmarksMenu/BookmarksItems",
-				       gtk_action_get_label (action),
-				       gtk_action_get_name (action),
+				       action_label,
+				       action_name,
 				       GTK_UI_MANAGER_MENUITEM,
 				       FALSE);
 
@@ -5162,11 +5208,13 @@ ev_window_update_continuous_action (EvWindow *window)
 {
 	GtkAction *action;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->priv->action_group, "ViewContinuous");
 	g_signal_handlers_block_by_func
 		(action, G_CALLBACK (ev_window_cmd_continuous), window);
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action),
 				      ev_document_model_get_continuous (window->priv->model));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_signal_handlers_unblock_by_func
 		(action, G_CALLBACK (ev_window_cmd_continuous), window);
 }
@@ -5203,11 +5251,13 @@ ev_window_update_inverted_colors_action (EvWindow *window)
 {
 	GtkAction *action;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->priv->action_group, "ViewInvertedColors");
 	g_signal_handlers_block_by_func
 		(action, G_CALLBACK (ev_window_cmd_view_inverted_colors), window);
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action),
 				      ev_document_model_get_inverted_colors (window->priv->model));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_signal_handlers_unblock_by_func
 		(action, G_CALLBACK (ev_window_cmd_view_inverted_colors), window);
 }
@@ -5233,11 +5283,13 @@ ev_window_update_dual_page_action (EvWindow *window)
 {
 	GtkAction *action;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->priv->action_group, "ViewDual");
 	g_signal_handlers_block_by_func
 		(action, G_CALLBACK (ev_window_cmd_dual), window);
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action),
 				      ev_document_model_get_dual_page (window->priv->model));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_signal_handlers_unblock_by_func
 		(action, G_CALLBACK (ev_window_cmd_dual), window);
 }
@@ -5259,11 +5311,13 @@ ev_window_update_dual_page_odd_pages_left_action (EvWindow *window)
 {
 	GtkAction *action;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->priv->action_group, "ViewDualOddLeft");
 	g_signal_handlers_block_by_func
 		(action, G_CALLBACK (ev_window_cmd_dual_odd_pages_left), window);
 	gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action),
 				      ev_document_model_get_dual_page_odd_pages_left (window->priv->model));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_signal_handlers_unblock_by_func
 		(action, G_CALLBACK (ev_window_cmd_dual_odd_pages_left), window);
 }
@@ -5387,7 +5441,9 @@ ev_window_view_toolbar_cb (GtkAction *action, EvWindow *ev_window)
 {
 	gboolean active;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	active = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	update_chrome_flag (ev_window, EV_CHROME_TOOLBAR, active);
 	update_chrome_visibility (ev_window);
 	if (ev_window->priv->metadata)
@@ -5400,8 +5456,10 @@ ev_window_view_sidebar_cb (GtkAction *action, EvWindow *ev_window)
 	if (EV_WINDOW_IS_PRESENTATION (ev_window))
 		return;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	update_chrome_flag (ev_window, EV_CHROME_SIDEBAR,
 			    gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action)));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	update_chrome_visibility (ev_window);
 }
 
@@ -5424,12 +5482,16 @@ ev_window_sidebar_visibility_changed_cb (EvSidebar  *ev_sidebar,
 {
 	GtkAction *action;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (ev_window->priv->action_group, "ViewSidebar");
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	if (!EV_WINDOW_IS_PRESENTATION (ev_window)) {
 		gboolean visible = gtk_widget_get_visible (GTK_WIDGET (ev_sidebar));
 
+		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), visible);
+		G_GNUC_END_IGNORE_DEPRECATIONS;
 
 		if (ev_window->priv->metadata)
 			ev_metadata_set_boolean (ev_window->priv->metadata, "sidebar_visibility",
@@ -5477,6 +5539,7 @@ view_menu_link_popup (EvWindow *ev_window,
 		}
 	}
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (ev_window->priv->view_popup_action_group,
 					      "OpenLink");
 	gtk_action_set_visible (action, show_external);
@@ -5492,6 +5555,7 @@ view_menu_link_popup (EvWindow *ev_window,
 	action = gtk_action_group_get_action (ev_window->priv->view_popup_action_group,
 					      "OpenLinkNewWindow");
 	gtk_action_set_visible (action, show_internal);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static void
@@ -5512,6 +5576,7 @@ view_menu_image_popup (EvWindow  *ev_window,
 
 	show_image = (ev_window->priv->image != NULL);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (ev_window->priv->view_popup_action_group,
 					      "SaveImageAs");
 	gtk_action_set_visible (action, show_image);
@@ -5519,6 +5584,7 @@ view_menu_image_popup (EvWindow  *ev_window,
 	action = gtk_action_group_get_action (ev_window->priv->view_popup_action_group,
 					      "CopyImage");
 	gtk_action_set_visible (action, show_image);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static void
@@ -5534,6 +5600,7 @@ view_menu_annot_popup (EvWindow     *ev_window,
 		g_object_unref (ev_window->priv->annot);
 	ev_window->priv->annot = (annot) ? g_object_ref (annot) : NULL;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (ev_window->priv->view_popup_action_group,
 					      "AnnotProperties");
 	gtk_action_set_visible (action, (annot != NULL && EV_IS_ANNOTATION_MARKUP (annot)));
@@ -5544,6 +5611,7 @@ view_menu_annot_popup (EvWindow     *ev_window,
 	action = gtk_action_group_get_action (ev_window->priv->view_popup_action_group,
 	                                      "RemoveAnnot");
 	gtk_action_set_visible (action, (annot != NULL && can_remove_annots));
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 
 	if (annot && EV_IS_ANNOTATION_ATTACHMENT (annot)) {
 		EvAttachment *attachment;
@@ -5563,6 +5631,7 @@ view_menu_annot_popup (EvWindow     *ev_window,
 		}
 	}
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (ev_window->priv->attachment_popup_action_group,
 					      "OpenAttachment");
 	gtk_action_set_visible (action, show_annot);
@@ -5570,6 +5639,7 @@ view_menu_annot_popup (EvWindow     *ev_window,
 	action = gtk_action_group_get_action (ev_window->priv->attachment_popup_action_group,
 					      "SaveAttachmentAs");
 	gtk_action_set_visible (action, show_annot);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static gboolean
@@ -6694,6 +6764,7 @@ register_custom_actions (EvWindow *window, GtkActionGroup *group)
 				  window->priv->model);
 	g_signal_connect (action, "activate_link",
 			  G_CALLBACK (activate_link_cb), window);
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gtk_action_group_add_action (group, action);
 	g_object_unref (action);
 
@@ -6735,6 +6806,7 @@ register_custom_actions (EvWindow *window, GtkActionGroup *group)
 			  G_CALLBACK (ev_window_open_recent_action_item_activated),
 			  window);
 	gtk_action_group_add_action (group, action);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	g_object_unref (action);
 }
 
@@ -6743,6 +6815,7 @@ set_action_properties (GtkActionGroup *action_group)
 {
 	GtkAction *action;
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (action_group, "FileSendTo");
 	/*translators: this is the label for toolbar button*/
 	g_object_set (action, "short_label", _("Send To"), NULL);
@@ -6780,6 +6853,7 @@ set_action_properties (GtkActionGroup *action_group)
 
 	action = gtk_action_group_get_action (action_group, "LeaveFullscreen");
 	g_object_set (action, "is-important", TRUE, NULL);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 }
 
 static void
@@ -6794,7 +6868,9 @@ sidebar_widget_model_set (EvSidebarLinks *ev_sidebar_links,
 		      "model", &model,
 		      NULL);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (ev_window->priv->action_group, PAGE_SELECTOR_ACTION);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	ev_page_action_set_links_model (EV_PAGE_ACTION (action), model);
 	g_object_unref (model);
 }
@@ -7762,6 +7838,7 @@ ev_window_init (EvWindow *ev_window)
 	gtk_container_add (GTK_CONTAINER (ev_window), ev_window->priv->main_box);
 	gtk_widget_show (ev_window->priv->main_box);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action_group = gtk_action_group_new ("MenuActions");
 	ev_window->priv->action_group = action_group;
 	gtk_action_group_set_translation_domain (action_group, NULL);
@@ -7770,6 +7847,7 @@ ev_window_init (EvWindow *ev_window)
 	gtk_action_group_add_toggle_actions (action_group, toggle_entries,
 					     G_N_ELEMENTS (toggle_entries),
 					     ev_window);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	set_action_properties (action_group);
 	register_custom_actions (ev_window, action_group);
 
@@ -7781,21 +7859,25 @@ ev_window_init (EvWindow *ev_window)
 		gtk_ui_manager_get_accel_group (ev_window->priv->ui_manager);
 	gtk_window_add_accel_group (GTK_WINDOW (ev_window), accel_group);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action_group = gtk_action_group_new ("ViewPopupActions");
 	ev_window->priv->view_popup_action_group = action_group;
 	gtk_action_group_set_translation_domain (action_group, NULL);
 	gtk_action_group_add_actions (action_group, view_popup_entries,
 				      G_N_ELEMENTS (view_popup_entries),
 				      ev_window);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	gtk_ui_manager_insert_action_group (ev_window->priv->ui_manager,
 					    action_group, 0);
 
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action_group = gtk_action_group_new ("AttachmentPopupActions");
 	ev_window->priv->attachment_popup_action_group = action_group;
 	gtk_action_group_set_translation_domain (action_group, NULL);
 	gtk_action_group_add_actions (action_group, attachment_popup_entries,
 				      G_N_ELEMENTS (attachment_popup_entries),
 				      ev_window);
+	G_GNUC_END_IGNORE_DEPRECATIONS;
 	gtk_ui_manager_insert_action_group (ev_window->priv->ui_manager,
 					    action_group, 0);
 


### PR DESCRIPTION
Suppress GtkAction warnings which can't be fixed without removing icons from menus.
So, no need to let them spam our build logs, in result you overlook really important warnings.
Show those warnings in debian build only, to make one team member happy.
Please review.