### PR TITLE
shell: Use monitor instead of screen to determine window size

### DIFF
--- a/libview/ev-view-presentation.c
+++ b/libview/ev-view-presentation.c
@@ -752,17 +752,43 @@ ev_view_presentation_goto_entry_grab_focus (EvViewPresentation *pview)
 }
 
 static void
+monitor_get_dimesions (EvViewPresentation *pview,
+		       gint     *width,
+		       gint     *height)
+{
+	GdkDisplay  *display;
+	GdkWindow   *gdk_window;
+	GdkMonitor  *monitor;
+	GdkRectangle geometry;
+
+	*width = 0;
+	*height = 0;
+
+	display = gtk_widget_get_display (GTK_WIDGET (pview));
+	gdk_window = gtk_widget_get_window (GTK_WIDGET (pview));
+
+	if (gdk_window) {
+		monitor = gdk_display_get_monitor_at_window (display,
+							     gdk_window);
+		gdk_monitor_get_workarea (monitor, &geometry);
+		*width = geometry.width;
+		*height = geometry.height;
+	}
+}
+
+static void
 ev_view_presentation_goto_window_send_key_event (EvViewPresentation *pview,
 						 GdkEvent           *event)
 {
 	GdkEventKey *new_event;
-	GdkScreen   *screen;
+	gint        monitor_width;
+	gint        monitor_height;
 
 	/* Move goto window off screen */
-	screen = gtk_widget_get_screen (GTK_WIDGET (pview));
+	monitor_get_dimesions (pview, &monitor_width, &monitor_height);
 	gtk_window_move (GTK_WINDOW (pview->goto_window),
-			 WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) + 1,
-			 HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) + 1);
+			 monitor_width + 1,
+			 monitor_height + 1);
 	gtk_widget_show (pview->goto_window);
 
 	new_event = (GdkEventKey *) gdk_event_copy (event);

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -1359,6 +1359,31 @@ setup_model_from_metadata (EvWindow *window)
 }
 
 static void
+monitor_get_dimesions (EvWindow *ev_window,
+		       gint     *width,
+		       gint     *height)
+{
+	GdkDisplay  *display;
+	GdkWindow   *gdk_window;
+	GdkMonitor  *monitor;
+	GdkRectangle geometry;
+
+	*width = 0;
+	*height = 0;
+
+	display = gtk_widget_get_display (GTK_WIDGET (ev_window));
+	gdk_window = gtk_widget_get_window (GTK_WIDGET (ev_window));
+
+	if (gdk_window) {
+		monitor = gdk_display_get_monitor_at_window (display,
+							     gdk_window);
+		gdk_monitor_get_workarea (monitor, &geometry);
+		*width = geometry.width;
+		*height = geometry.height;
+	}
+}
+
+static void
 setup_document_from_metadata (EvWindow *window)
 {
 	gint    page, n_pages;
@@ -1390,9 +1415,10 @@ setup_document_from_metadata (EvWindow *window)
 	if (width_ratio > 0. && height_ratio > 0.) {
 		gdouble    document_width;
 		gdouble    document_height;
-		GdkScreen *screen;
 		gint       request_width;
 		gint       request_height;
+		gint       monitor_width;
+		gint       monitor_height;
 
 		ev_document_get_max_page_size (window->priv->document,
 					       &document_width, &document_height);
@@ -1400,10 +1426,10 @@ setup_document_from_metadata (EvWindow *window)
 		request_width = (gint)(width_ratio * document_width + 0.5);
 		request_height = (gint)(height_ratio * document_height + 0.5);
 
-		screen = gtk_window_get_screen (GTK_WINDOW (window));
-		if (screen) {
-			request_width = MIN (request_width, WidthOfScreen (gdk_x11_screen_get_xscreen (screen)));
-			request_height = MIN (request_height, HeightOfScreen (gdk_x11_screen_get_xscreen (screen)));
+		monitor_get_dimesions (window, &monitor_width, &monitor_height);
+		if (monitor_width > 0 && monitor_height > 0) {
+			request_width = MIN (request_width, monitor_width);
+			request_height = MIN (request_height, monitor_height);
 		}
 
 		if (request_width > 0 && request_height > 0) {


### PR DESCRIPTION
replace WidthOfScreen which works only with X11

inspired from:
https://gitlab.gnome.org/GNOME/evince/commit/40aa446

Please test.