### PR TITLE
Fix build warning on marshalling

### DIFF
--- a/cut-n-paste/toolbar-editor/Makefile.am
+++ b/cut-n-paste/toolbar-editor/Makefile.am
@@ -50,7 +50,7 @@ stamp-eggmarshalers.h: eggmarshalers.list
 eggmarshalers.c: stamp-eggmarshalers.c
 	@true
 stamp-eggmarshalers.c: eggmarshalers.list
-	$(AM_V_GEN)$(GLIB_GENMARSHAL) --prefix=_egg_marshal $(srcdir)/eggmarshalers.list --header --body > eggmarshalers.c \
+	$(AM_V_GEN)$(GLIB_GENMARSHAL) --prefix=_egg_marshal $(srcdir)/eggmarshalers.list --body --prototypes > eggmarshalers.c \
 	&& echo timestamp > $(@F)
 
 eggtypebuiltins.c: stamp-eggtypebuiltins.c

--- a/libview/Makefile.am
+++ b/libview/Makefile.am
@@ -101,7 +101,7 @@ ev-view-marshal.h: $(srcdir)/ev-view-marshal.list
 
 ev-view-marshal.c: $(srcdir)/ev-view-marshal.list
 	echo '#include <config.h>' > ev-view-marshal.c
-	$(AM_V_GEN)$(GLIB_GENMARSHAL) --prefix=ev_view_marshal $(srcdir)/ev-view-marshal.list --header --internal --body >> $@
+	$(AM_V_GEN)$(GLIB_GENMARSHAL) --prefix=ev_view_marshal $(srcdir)/ev-view-marshal.list --internal --body --prototypes >> $@
 
 ev-view-type-builtins.h: stamp-ev-view-type-builtins.h
 	@true


### PR DESCRIPTION
Replace deprecated --header --body options

inspired by:
https://gitlab.gnome.org/GNOME/evince/commit/f6952c2