### PR TITLE
tiff: Handle failure from TIFFReadRGBAImageOriented

### DIFF
--- a/backend/tiff/tiff-document.c
+++ b/backend/tiff/tiff-document.c
@@ -282,17 +282,21 @@ tiff_document_render (EvDocument      *document,
 		return NULL;
 	}
 
+	if (!TIFFReadRGBAImageOriented (tiff_document->tiff,
+					width, height,
+					(uint32 *)pixels,
+					orientation, 0)) {
+		g_warning ("Failed to read TIFF image.");
+		g_free (pixels);
+		return NULL;
+	}
+
 	surface = cairo_image_surface_create_for_data (pixels,
 						       CAIRO_FORMAT_RGB24,
 						       width, height,
 						       rowstride);
 	cairo_surface_set_user_data (surface, &key,
 				     pixels, (cairo_destroy_func_t)g_free);
-
-	TIFFReadRGBAImageOriented (tiff_document->tiff,
-				   width, height,
-				   (uint32 *)pixels,
-				   orientation, 0);
 	pop_handlers ();
 
 	/* Convert the format returned by libtiff to
@@ -373,13 +377,17 @@ tiff_document_render_pixbuf (EvDocument      *document,
 	if (!pixels)
 		return NULL;
 
+	if (!TIFFReadRGBAImageOriented (tiff_document->tiff,
+					width, height,
+					(uint32 *)pixels,
+					ORIENTATION_TOPLEFT, 0)) {
+		g_free (pixels);
+		return NULL;
+	}
+
 	pixbuf = gdk_pixbuf_new_from_data (pixels, GDK_COLORSPACE_RGB, TRUE, 8,
 					   width, height, rowstride,
 					   (GdkPixbufDestroyNotify) g_free, NULL);
-	TIFFReadRGBAImageOriented (tiff_document->tiff,
-				   width, height,
-				   (uint32 *)pixels,
-				   ORIENTATION_TOPLEFT, 0);
 	pop_handlers ();
 
 	scaled_pixbuf = gdk_pixbuf_scale_simple (pixbuf,


### PR DESCRIPTION
The TIFFReadRGBAImageOriented function returns zero if it was unable to
read the image. Return NULL in this case instead of displaying
uninitialized memory.

This addresses CVE-2019-11459
Fixes #393 

upstream commit:
https://gitlab.gnome.org/GNOME/evince/commit/234f034a4