### PR TITLE
synctex_parser: Fix warning: implicit declaration function 'vasprintf'

### DIFF
--- a/cut-n-paste/synctex/synctex_parser.c
+++ b/cut-n-paste/synctex/synctex_parser.c
@@ -83,6 +83,11 @@
  *  First level objects are sheets and forms, containing boxes, glues, kerns...
  *  The third tree allows to browse leaves according to tag and line.
  */
+
+#ifndef _GNU_SOURCE
+    #define _GNU_SOURCE
+#endif
+
 #   if defined(SYNCTEX_USE_LOCAL_HEADER)
 #       include "synctex_parser_local.h"
 #   else


### PR DESCRIPTION
Fixes the warning:

```
synctex_parser.c: In function '_synctex_updater_print_gz':
synctex_parser.c:8450:13: warning: implicit declaration of function 'vasprintf'; did you mean 'vsprintf'? [-Wimplicit-function-declaration]
 8450 |         if (vasprintf(&buffer, format, va) < 0) {
      |             ^~~~~~~~~
      |             vsprintf
```