### PR TITLE
remove -Wunused-but-set-variable warning

### DIFF
--- a/cut-n-paste/zoom-control/ephy-zoom-control.c
+++ b/cut-n-paste/zoom-control/ephy-zoom-control.c
@@ -271,10 +271,8 @@ static void
 ephy_zoom_control_class_init (EphyZoomControlClass *klass)
 {
 	GObjectClass *object_class;
-	GtkToolItemClass *tool_item_class;
 
 	object_class = (GObjectClass *)klass;
-	tool_item_class = (GtkToolItemClass *)klass;
 
 	object_class->set_property = ephy_zoom_control_set_property;
 	object_class->get_property = ephy_zoom_control_get_property;

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -1387,7 +1387,7 @@ monitor_get_dimesions (EvWindow *ev_window,
 static void
 setup_document_from_metadata (EvWindow *window)
 {
-	gint    page, n_pages;
+	gint    n_pages;
 	gint    width;
 	gint    height;
 	gdouble width_ratio;
@@ -1402,7 +1402,6 @@ setup_document_from_metadata (EvWindow *window)
 	 * since closing it on the last page most likely means the
 	 * user was finished reading the document. In that case, reopening should
 	 * show the first page. */
-	page = ev_document_model_get_page (window->priv->model);
 	n_pages = ev_document_get_n_pages (window->priv->document);
 
 	if (ev_metadata_get_int (window->priv->metadata, "window_width", &width) &&


### PR DESCRIPTION
```
ephy-zoom-control.c:274:20: warning: variable ‘tool_item_class’ set but not used [-Wunused-but-set-variable]
  274 |  GtkToolItemClass *tool_item_class;
      |                    ^~~~~~~~~~~~~~~
--
ev-window.c:1390:10: warning: variable ‘page’ set but not used [-Wunused-but-set-variable]
 1390 |  gint    page, n_pages;
      |          ^~~~
```