### PR TITLE
Fix for #365 ("Odd Pages Left" accelerator).

### DIFF
--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -6613,7 +6613,7 @@ static const GtkToggleActionEntry toggle_entries[] = {
         { "ViewDual", EV_STOCK_VIEW_DUAL, N_("_Dual"), "d",
 	  N_("Show two pages at once"),
 	  G_CALLBACK (ev_window_cmd_dual), FALSE },
-	{ "ViewDualOddLeft", NULL, N_("_Odd pages left"), NULL,
+	{ "ViewDualOddLeft", NULL, N_("_Odd pages left"), "o",
 	  N_("Show odd pages on the left in dual mode"),
 	  G_CALLBACK (ev_window_cmd_dual_odd_pages_left), FALSE },
         { "ViewFullscreen", "view-fullscreen", N_("_Fullscreen"), "F11",


### PR DESCRIPTION
As requested in #365 to add accelerator for "Odd Pages Left" in dual page mode.
The character "o" was chosen as suggested, no other accelerator is bound to that character.