### PR TITLE
point info dialog website to github

### DIFF
--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -5448,7 +5448,7 @@ ev_window_cmd_help_about (GtkAction *action, EvWindow *ev_window)
 		"copyright", _("Copyright \xc2\xa9 1996–2009 The Evince authors\n"
 		               "Copyright \xc2\xa9 2012–2019 The MATE developers"),
 		"license", license_trans,
-		"website", "https://mate-desktop.org/",
+		"website", "https://github.com/mate-desktop/atril",
 		"comments", comments,
 		"authors", authors,
 		"documenters", documenters,


### PR DESCRIPTION
For me as a user this is much more useful than the link to https://mate-desktop.org/, as it points me directly to the official repo instead of searching on the mate website – even without success.