### PR TITLE
libview: Reset `pressed_button` when starting Drag and Drop

### DIFF
--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -4808,6 +4808,7 @@ ev_view_motion_notify_event (GtkWidget      *widget,
 					                 event->y);
 
 			view->selection_info.in_drag = FALSE;
+			view->pressed_button = -1;
 
 			gtk_target_list_unref (target_list);
 
@@ -4830,6 +4831,7 @@ ev_view_motion_notify_event (GtkWidget      *widget,
 					                 event->y);
 
 			view->image_dnd_info.in_drag = FALSE;
+			view->pressed_button = -1;
 
 			gtk_target_list_unref (target_list);
 


### PR DESCRIPTION
If view->pressed_button is left set, when the Drag and Drop operation completes, Atril will act as if it is still in a selection event.

Adapted from: https://gitlab.gnome.org/GNOME/evince/commit/92828bb797742e04aadbfdd62ba1da36837c37cf
