### PR TITLE
Fix mem when zooming

### DIFF
--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -164,20 +164,27 @@ ev_pixbuf_cache_finalize (GObject *object)
 }
 
 static void
+end_job (CacheJobInfo *job_info,
+	 gpointer      data)
+{
+	g_signal_handlers_disconnect_by_func (job_info->job,
+					      G_CALLBACK (job_finished_cb),
+					      data);
+	ev_job_cancel (job_info->job);
+	g_object_unref (job_info->job);
+	job_info->job = NULL;
+}
+
+static void
 dispose_cache_job_info (CacheJobInfo *job_info,
 			gpointer      data)
 {
 	if (job_info == NULL)
 		return;
 
-	if (job_info->job) {
-		g_signal_handlers_disconnect_by_func (job_info->job,
-						      G_CALLBACK (job_finished_cb),
-						      data);
-		ev_job_cancel (job_info->job);
-		g_object_unref (job_info->job);
-		job_info->job = NULL;
-	}
+	if (job_info->job)
+		end_job (job_info, data);
+
 	if (job_info->surface) {
 		cairo_surface_destroy (job_info->surface);
 		job_info->surface = NULL;
@@ -300,14 +307,8 @@ copy_job_to_job_info (EvJobRender   *job_render,
 		job_info->points_set = TRUE;
 	}
 
-	if (job_info->job) {
-		g_signal_handlers_disconnect_by_func (job_info->job,
-						      G_CALLBACK (job_finished_cb),
-						      pixbuf_cache);
-		ev_job_cancel (job_info->job);
-		g_object_unref (job_info->job);
-		job_info->job = NULL;
-	}
+	if (job_info->job)
+		end_job (job_info, pixbuf_cache);
 
 	job_info->page_ready = TRUE;
 }
@@ -360,12 +361,7 @@ check_job_size_and_unref (EvPixbufCache *pixbuf_cache,
 			return;
 	}
 
-	g_signal_handlers_disconnect_by_func (job_info->job,
-					      G_CALLBACK (job_finished_cb),
-					      pixbuf_cache);
-	ev_job_cancel (job_info->job);
-	g_object_unref (job_info->job);
-	job_info->job = NULL;
+	end_job (job_info, pixbuf_cache);
 }
 
 /* Do all function that copies a job from an older cache to it's position in the
@@ -674,6 +670,9 @@ add_job (EvPixbufCache  *pixbuf_cache,
 	if (job_info->region)
 		cairo_region_destroy (job_info->region);
 	job_info->region = region ? cairo_region_reference (region) : NULL;
+
+	if (job_info->job)
+		end_job (job_info, pixbuf_cache);
 
 	job_info->job = ev_job_render_new (pixbuf_cache->document,
 	                                   page, rotation,

--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -103,7 +103,7 @@ static gboolean      new_selection_surface_needed(EvPixbufCache      *pixbuf_cac
 #define PAGE_CACHE_LEN(pixbuf_cache) \
 	(pixbuf_cache->start_page>=0?((pixbuf_cache->end_page - pixbuf_cache->start_page) + 1):0)
 
-#define MAX_PRELOADED_PAGES 20
+#define MAX_PRELOADED_PAGES 3
 
 G_DEFINE_TYPE (EvPixbufCache, ev_pixbuf_cache, G_TYPE_OBJECT)
 

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -790,13 +790,12 @@ view_update_range_and_current_page (EvView *view)
 		ev_view_check_cursor_blink (view);
 	}
 
-	#define PAGE_CACHE_NUMBER  10
 	ev_page_cache_set_page_range (view->page_cache,
-				      MAX(view->start_page - PAGE_CACHE_NUMBER, 0),
-				      MIN(view->end_page + PAGE_CACHE_NUMBER, ev_document_get_n_pages (view->document) - 1));
+				      view->start_page,
+				      view->end_page);
 	ev_pixbuf_cache_set_page_range (view->pixbuf_cache,
-					MAX(view->start_page - PAGE_CACHE_NUMBER, 0),
-					MIN(view->end_page + PAGE_CACHE_NUMBER, ev_document_get_n_pages (view->document) - 1),
+					view->start_page,
+					view->end_page,
 					view->selection_info.selections);
 	if (view->accessible)
 		ev_view_accessible_set_page_range (EV_VIEW_ACCESSIBLE (view->accessible),


### PR DESCRIPTION
Fixes https://github.com/mate-desktop/atril/issues/404
First commit reverts https://github.com/mate-desktop/atril/pull/240 and fixes the huge memory consumption with max zoom, and second commit improve memory consumption in libview.
Note, you need to increase page-cache-size to reach higher zoom levels with this PR, default is 50MB.
```
gsettings get org.mate.Atril page-cache-size
200
```
With this setting a huge pdf doesn't use more than  ~1GB memory with 400% zoom.

Atril on master branch use more than 4.7 GB with same document, 50MB page-cache-size and 400% zoom, and a system with with 16 GB RAM can run out of memory when increasing page-cache-size. 
Note, on systems without using HIDPI the effect isn't so heavy.

Please test.