### PR TITLE
Travis CI: add '-Wredundant-decls' to 'CFLAGS' variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -173,7 +173,7 @@ requires:
     - zlib1g-dev
 
 variables:
-  - CFLAGS="-Wall -Werror=format-security"
+  - CFLAGS="-Wall -Werror=format-security -Wredundant-decls"
   - 'CHECKERS="
     -enable-checker deadcode.DeadStores
     -enable-checker alpha.deadcode.UnreachableCode


### PR DESCRIPTION
With this PR in the future we will see the "redundant redeclarations" warnings in the logs (warnings already fixed)