### PR TITLE
Fix year 2038 issue with signed 32-bit integers

### DIFF
--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -667,11 +667,12 @@ pdf_document_get_info (EvDocument *document)
 		      "permissions", &permissions,
 		      "creator", &(info->creator),
 		      "producer", &(info->producer),
-		      "creation-date", &(info->creation_date),
-		      "mod-date", &(info->modified_date),
 		      "linearized", &linearized,
 		      "metadata", &metadata,
 		      NULL);
+
+	info->creation_date = (gint64) poppler_document_get_creation_date (PDF_DOCUMENT (document)->document);
+	info->modified_date = (gint64) poppler_document_get_modification_date (PDF_DOCUMENT (document)->document);
 
 	if (metadata != NULL) {
 		pdf_document_parse_metadata (metadata, info);

--- a/configure.ac
+++ b/configure.ac
@@ -84,7 +84,7 @@ GLIB_GSETTINGS
 
 dnl Specify required versions of dependencies
 CAIRO_REQUIRED=1.14.0
-GLIB_REQUIRED=2.54.0
+GLIB_REQUIRED=2.62.0
 GTK_REQUIRED=3.22.0
 WEBKIT_REQUIRED=2.6.0
 LIBSECRET_REQUIRED=0.5
@@ -643,8 +643,6 @@ if test "x$have_webkit" = "xyes"; then
 fi
 
 AC_SUBST(ATRIL_MIME_TYPES)
-
-AC_CHECK_FUNC(localtime_r, AC_DEFINE(HAVE_LOCALTIME_R, 1, [Defines if localtime_r is available on your system]))
 
 # *****************
 # Help files

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -454,7 +454,7 @@ ev_annotation_get_modified (EvAnnotation *annot)
  * @modified: string with the last modification date.
  *
  * Set the last modification date of @annot to @modified. To
- * set the last modification date using a #GTime, use
+ * set the last modification date using a #gint64, use
  * ev_annotation_set_modified_from_time() instead. You can monitor
  * changes to the last modification date by connecting to the
  * notify::modified signal on @annot.
@@ -482,7 +482,7 @@ ev_annotation_set_modified (EvAnnotation *annot,
 /**
  * ev_annotation_set_modified_from_time:
  * @annot: an #EvAnnotation
- * @utime: a #GTime
+ * @utime: a #gint64
  *
  * Set the last modification date of @annot to @utime.  You can
  * monitor changes to the last modification date by connectin to the
@@ -493,7 +493,7 @@ ev_annotation_set_modified (EvAnnotation *annot,
  */
 gboolean
 ev_annotation_set_modified_from_time (EvAnnotation *annot,
-				      GTime         utime)
+				      gint64        utime)
 {
 	gchar *modified;
 

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -115,7 +115,7 @@ const gchar         *ev_annotation_get_modified              (EvAnnotation      
 gboolean             ev_annotation_set_modified              (EvAnnotation           *annot,
 							      const gchar            *modified);
 gboolean             ev_annotation_set_modified_from_time    (EvAnnotation           *annot,
-							      GTime                   utime);
+							      gint64                  utime);
 EV_DEPRECATED_FOR(ev_annotaion_get_rgba)
 void                 ev_annotation_get_color                 (EvAnnotation           *annot,
 							      GdkColor               *color);

--- a/libdocument/ev-attachment.c
+++ b/libdocument/ev-attachment.c
@@ -38,8 +38,8 @@ enum
 struct _EvAttachmentPrivate {
 	gchar                   *name;
 	gchar                   *description;
-	GTime                    mtime;
-	GTime                    ctime;
+	gint64                   mtime;
+	gint64                   ctime;
 	gsize                    size;
 	gchar                   *data;
 	gchar                   *mime_type;
@@ -217,8 +217,8 @@ ev_attachment_init (EvAttachment *attachment)
 EvAttachment *
 ev_attachment_new (const gchar *name,
 		   const gchar *description,
-		   GTime        mtime,
-		   GTime        ctime,
+		   gint64       mtime,
+		   gint64       ctime,
 		   gsize        size,
 		   gpointer     data)
 {
@@ -252,7 +252,7 @@ ev_attachment_get_description (EvAttachment *attachment)
 	return attachment->priv->description;
 }
 
-GTime
+gint64
 ev_attachment_get_modification_date (EvAttachment *attachment)
 {
 	g_return_val_if_fail (EV_IS_ATTACHMENT (attachment), 0);
@@ -260,7 +260,7 @@ ev_attachment_get_modification_date (EvAttachment *attachment)
 	return attachment->priv->mtime;
 }
 
-GTime
+gint64
 ev_attachment_get_creation_date (EvAttachment *attachment)
 {
 	g_return_val_if_fail (EV_IS_ATTACHMENT (attachment), 0);

--- a/libdocument/ev-attachment.h
+++ b/libdocument/ev-attachment.h
@@ -56,15 +56,15 @@ GType         ev_attachment_get_type             (void) G_GNUC_CONST;
 GQuark        ev_attachment_error_quark          (void) G_GNUC_CONST;
 EvAttachment *ev_attachment_new                  (const gchar  *name,
 						  const gchar  *description,
-						  GTime         mtime,
-						  GTime         ctime,
+						  gint64        mtime,
+						  gint64        ctime,
 						  gsize         size,
 						  gpointer      data);
 
 const gchar *ev_attachment_get_name              (EvAttachment *attachment);
 const gchar *ev_attachment_get_description       (EvAttachment *attachment);
-GTime        ev_attachment_get_modification_date (EvAttachment *attachment);
-GTime        ev_attachment_get_creation_date     (EvAttachment *attachment);
+gint64       ev_attachment_get_modification_date (EvAttachment *attachment);
+gint64       ev_attachment_get_creation_date     (EvAttachment *attachment);
 const gchar *ev_attachment_get_mime_type         (EvAttachment *attachment);
 gboolean     ev_attachment_save                  (EvAttachment *attachment,
 						  GFile        *file,

--- a/libdocument/ev-document-info.h
+++ b/libdocument/ev-document-info.h
@@ -115,8 +115,8 @@ struct _EvDocumentInfo
 	char *producer;
 	char *linearized;
         char *security;
-	GTime creation_date;
-	GTime modified_date;
+	gint64 creation_date;
+	gint64 modified_date;
 	EvDocumentLayout layout;
 	EvDocumentMode mode;
 	guint ui_hints;

--- a/libdocument/ev-document-misc.c
+++ b/libdocument/ev-document-misc.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <math.h>
 
+#include <glib.h>
 #include <gtk/gtk.h>
 #include <gdk/gdkx.h>
 
@@ -359,25 +360,17 @@ ev_document_misc_get_monitor_dpi (GdkMonitor *monitor)
 
 /* Returns a locale specific date and time representation */
 gchar *
-ev_document_misc_format_date (GTime utime)
+ev_document_misc_format_date (gint64 utime)
 {
-	time_t time = (time_t) utime;
-	char s[256];
-	const char fmt_hack[] = "%c";
-	size_t len;
-#ifdef HAVE_LOCALTIME_R
-	struct tm t;
-	if (time == 0 || !localtime_r (&time, &t)) return NULL;
-	len = strftime (s, sizeof (s), fmt_hack, &t);
-#else
-	struct tm *t;
-	if (time == 0 || !(t = localtime (&time)) ) return NULL;
-	len = strftime (s, sizeof (s), fmt_hack, t);
-#endif
+	GDateTime *date_time;
+	gchar     *result = NULL;
 
-	if (len == 0 || s[0] == '\0') return NULL;
-
-	return g_locale_to_utf8 (s, -1, NULL, NULL, NULL);
+	date_time = g_date_time_new_from_unix_local (utime);
+	if (date_time != NULL) {
+		result = g_date_time_format (date_time, "%c");
+		g_date_time_unref (date_time);
+	}
+	return result;
 }
 
 void

--- a/libdocument/ev-document-misc.h
+++ b/libdocument/ev-document-misc.h
@@ -63,7 +63,7 @@ void             ev_document_misc_invert_pixbuf  (GdkPixbuf       *pixbuf);
 
 gdouble          ev_document_misc_get_monitor_dpi (GdkMonitor *monitor);
 
-gchar           *ev_document_misc_format_date (GTime utime);
+gchar           *ev_document_misc_format_date (gint64 utime);
 
 void             ev_document_misc_get_pointer_position (GtkWidget *widget,
 							gint      *x,

--- a/properties/ev-properties-view.c
+++ b/properties/ev-properties-view.c
@@ -342,12 +342,12 @@ ev_properties_view_set_info (EvPropertiesView *properties, const EvDocumentInfo 
 	if (info->fields_mask & EV_DOCUMENT_INFO_CREATOR) {
 		set_property (properties, GTK_GRID (grid), CREATOR_PROPERTY, info->creator, &row);
 	}
-	if (info->fields_mask & EV_DOCUMENT_INFO_CREATION_DATE) {
+	if ((info->fields_mask & EV_DOCUMENT_INFO_CREATION_DATE) && (info->creation_date > 0)) {
 		text = ev_document_misc_format_date (info->creation_date);
 		set_property (properties, GTK_GRID (grid), CREATION_DATE_PROPERTY, text, &row);
 		g_free (text);
 	}
-	if (info->fields_mask & EV_DOCUMENT_INFO_MOD_DATE) {
+	if ((info->fields_mask & EV_DOCUMENT_INFO_MOD_DATE) && (info->modified_date > 0)) {
 		text = ev_document_misc_format_date (info->modified_date);
 		set_property (properties, GTK_GRID (grid), MOD_DATE_PROPERTY, text, &row);
 		g_free (text);


### PR DESCRIPTION
GTime is defined to always be a signed 32-bit integer, it will
overflow in the year 2038.

Test: Modified time = 2147617954 > 2^31

### pdf file has no date in metadata and file date is 2k38

```shell
 $ exiftool -all=  file.pdf
 $ touch -t 203801201732.34 file.pdf
 $ LANG=C gio info -a time::modified mozilla.pdf
 uri: file:///home/robert/mozilla.pdf
 attributes:
   time::modified: 2147617954
 $ LANG=C date -d "@2147617954" +"%c"
 Wed Jan 20 17:32:34 2038
 $ exiftool -all:all file.pdf
 ExifTool Version Number         : 11.70
 File Name                       : file.pdf
 Directory                       : .
 File Size                       : 375 kB
 File Modification Date/Time     : 2038:01:20 17:32:34+01:00
 File Access Date/Time           : 2038:01:20 17:32:34+01:00
 File Inode Change Date/Time     : 2020:01:20 21:42:32+01:00
 File Permissions                : rw-rw-r--
 File Type                       : PDF
 File Type Extension             : pdf
 MIME Type                       : application/pdf
 PDF Version                     : 1.5
 Linearized                      : No
 Page Count                      : 3
```
Before
![Screenshot at 2020-01-20 17-55-10](https://user-images.githubusercontent.com/10171411/72757815-4892b800-3bd1-11ea-84c2-17c91f43ed03.png)

After
![Screenshot at 2020-01-20 22-01-55](https://user-images.githubusercontent.com/10171411/72757825-4cbed580-3bd1-11ea-9b58-cbdbdff49157.png)

### all dates in metadata are 2k38
```shell
 $ exiftool -all=  file.pdf
 $ exiftool "-AllDates=2038:01:20 17:32:34" file.pdf
 $ exiftool -all:all file.pdf
 ExifTool Version Number         : 11.70
 File Name                       : file.pdf
 Directory                       : .
 File Size                       : 378 kB
 File Modification Date/Time     : 2020:01:20 21:44:33+01:00
 File Access Date/Time           : 2020:01:20 21:44:33+01:00
 File Inode Change Date/Time     : 2020:01:20 21:44:33+01:00
 File Permissions                : rw-rw-r--
 File Type                       : PDF
 File Type Extension             : pdf
 MIME Type                       : application/pdf
 PDF Version                     : 1.5
 Linearized                      : No
 Page Count                      : 3
 XMP Toolkit                     : Image::ExifTool 11.70
 Date/Time Original              : 2038:01:20 17:32:34
 Create Date                     : 2038:01:20 17:32:34
 Modify Date                     : 2038:01:20 17:32:34
```
Before
![Screenshot at 2020-01-20 22-06-02](https://user-images.githubusercontent.com/10171411/72757892-77a92980-3bd1-11ea-8206-1bd36f3b0fe8.png)

After
![Screenshot at 2020-01-20 22-04-58](https://user-images.githubusercontent.com/10171411/72757903-80016480-3bd1-11ea-9b17-1082d077a9e5.png)
