### PR TITLE
Make synctex an optional dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -362,9 +362,12 @@ AM_CONDITIONAL([ENABLE_INTROSPECTION],[test "$enable_introspection" = "yes"])
 
 dnl ================== libsynctex ===========================================
 AC_ARG_ENABLE([synctex],
-  [AS_HELP_STRING([--disable-synctex], [Disable support for synctex])],
-  [],
-  [enable_synctex=yes])
+  [--enable-synctex  enable support for synctex)],
+  [case "${enableval}" in
+    yes) synctex=true ;;
+    no)  synctex=false;;
+    *) AC_MSG_ERROR([bad value ${enableval} for --enable-synctex]) ;;
+  esac],[enable_synctex=yes])
 
 
 if test "$enable_synctex" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -361,15 +361,25 @@ AC_SUBST([GIRTYPELIBDIR])
 AM_CONDITIONAL([ENABLE_INTROSPECTION],[test "$enable_introspection" = "yes"])
 
 dnl ================== libsynctex ===========================================
+AC_ARG_ENABLE([synctex],
+  [AS_HELP_STRING([--disable-synctex], [Disable support for synctex])],
+  [],
+  [enable_synctex=yes])
 
-PKG_CHECK_MODULES(SYNCTEX, [synctex >= $SYNCTEX_REQUIRED], has_synctex=yes, has_synctex=no)
 
-dnl not found? use internal code copy.
-if test "x$has_synctex" = "xno"; then
-        AC_MSG_ERROR("SyncTeX support is disabled since library version $SYNCTEX_REQUIRED or newer not found")
+if test "$enable_synctex" = "yes"; then
+  AC_DEFINE([ENABLE_SYNCTEX],[1],[Define if synctex support is enabled])
+  PKG_CHECK_MODULES(SYNCTEX, [synctex >= $SYNCTEX_REQUIRED], has_synctex=yes, has_synctex=no)
+  dnl not found? use internal code copy.
+  if test "x$has_synctex" = "xno"; then
+          AC_MSG_ERROR("SyncTeX support is disabled since library version $SYNCTEX_REQUIRED or newer not found")
+  fi
+  AC_SUBST(SYNCTEX_LIBS)
+  AC_SUBST(SYNCTEX_CFLAGS)
 fi
-AC_SUBST(SYNCTEX_LIBS)
-AC_SUBST(SYNCTEX_CFLAGS)
+
+AM_CONDITIONAL([ENABLE_SYNCTEX], [test "$enable_synctex" = "yes"])
+
 
 dnl ================== portability checks ===========================================
 
@@ -776,6 +786,7 @@ Configure summary:
     Tests...............:    $enable_tests
 
     PDF Backend.........:    $enable_pdf
+    Synctex enabled.....:    $enable_synctex
     PostScript Backend..:    $enable_ps
     TIFF Backend........:    $enable_tiff
     DJVU Backend........:    $enable_djvu
@@ -784,6 +795,4 @@ Configure summary:
     Comics Backend......:    $enable_comics
     XPS Backend.........:    $enable_xps
     ePub Backend........:    $have_webkit
-
-    SyncTeX.............:    $has_synctex
 "

--- a/libdocument/Makefile.am
+++ b/libdocument/Makefile.am
@@ -102,10 +102,13 @@ libatrildocument_la_CPPFLAGS = \
 
 libatrildocument_la_CFLAGS = \
 	$(LIBDOCUMENT_CFLAGS)			\
-	$(SYNCTEX_CFLAGS)			\
 	$(WARN_CFLAGS)				\
 	$(DISABLE_DEPRECATED)			\
 	$(AM_CFLAGS)
+
+if ENABLE_SYNCTEX
+libatrildocument_la_CFLAGS += $(SYNCTEX_CFLAGS)
+endif
 
 libatrildocument_la_LDFLAGS = \
 	-version-info $(EV_DOCUMENT_LT_VERSION_INFO)	\
@@ -116,9 +119,11 @@ libatrildocument_la_LDFLAGS = \
 libatrildocument_la_LIBADD = \
 	$(LIBDOCUMENT_LIBS)	\
 	$(GMODULE_LIBS)		\
-	$(SYNCTEX_LIBS)		\
 	$(ZLIB_LIBS)
 
+if ENABLE_SYNCTEX
+libatrildocument_la_LIBADD += $(SYNCTEX_LIBS)
+endif
 
 BUILT_SOURCES = 			\
 	ev-document-type-builtins.c	\

--- a/libdocument/ev-document.c
+++ b/libdocument/ev-document.c
@@ -25,7 +25,9 @@
 #include <string.h>
 
 #include "ev-document.h"
+#ifdef ENABLE_SYNCTEX
 #include "synctex_parser.h"
+#endif
 #include "ev-file-helpers.h"
 
 typedef struct _EvPageSize
@@ -53,8 +55,9 @@ struct _EvDocumentPrivate
 	gchar         **page_labels;
 	EvPageSize     *page_sizes;
 	EvDocumentInfo *info;
-
+#ifdef ENABLE_SYNCTEX
 	synctex_scanner_p synctex_scanner;
+#endif
 };
 
 static gint            _ev_document_get_n_pages     (EvDocument *document);
@@ -124,12 +127,12 @@ ev_document_finalize (GObject *object)
 		ev_document_info_free (document->priv->info);
 		document->priv->info = NULL;
 	}
-
+#ifdef ENABLE_SYNCTEX
 	if (document->priv->synctex_scanner) {
 		synctex_scanner_free (document->priv->synctex_scanner);
 		document->priv->synctex_scanner = NULL;
 	}
-
+#endif
 	G_OBJECT_CLASS (ev_document_parent_class)->finalize (object);
 }
 
@@ -137,8 +140,9 @@ static void
 ev_document_init (EvDocument *document)
 {
 	document->priv = ev_document_get_instance_private (document);
+#ifdef ENABLE_SYNCTEX
 	document->synctex_version = SYNCTEX_VERSION_STRING;
-
+#endif
 	/* Assume all pages are the same size until proven otherwise */
 	document->priv->uniform = TRUE;
 	/* Assume that the document is not a web document*/
@@ -336,6 +340,7 @@ ev_document_load (EvDocument  *document,
 		}
 
 		priv->info = _ev_document_get_info (document);
+#ifdef ENABLE_SYNCTEX
 		if (_ev_document_support_synctex (document)) {
 			gchar *filename;
 
@@ -346,6 +351,7 @@ ev_document_load (EvDocument  *document,
 				g_free (filename);
 			}
 		}
+#endif
 	}
 
 	return retval;
@@ -388,6 +394,7 @@ _ev_document_support_synctex (EvDocument *document)
 	return klass->support_synctex ? klass->support_synctex (document) : FALSE;
 }
 
+#ifdef ENABLE_SYNCTEX
 gboolean
 ev_document_has_synctex (EvDocument *document)
 {
@@ -492,6 +499,7 @@ ev_document_synctex_forward_search (EvDocument   *document,
 
         return result;
 }
+#endif /* ENABLE_SYNCTEX */
 
 static gint
 _ev_document_get_n_pages (EvDocument  *document)

--- a/libdocument/ev-document.c
+++ b/libdocument/ev-document.c
@@ -68,7 +68,9 @@ static void            _ev_document_get_page_size   (EvDocument *document,
 static gchar          *_ev_document_get_page_label  (EvDocument *document,
 						     EvPage     *page);
 static EvDocumentInfo *_ev_document_get_info        (EvDocument *document);
+#ifdef ENABLE_SYNCTEX
 static gboolean        _ev_document_support_synctex (EvDocument *document);
+#endif
 
 static GMutex ev_doc_mutex;
 static GMutex ev_fc_mutex;
@@ -386,6 +388,8 @@ ev_document_get_page (EvDocument *document,
 	return klass->get_page (document, index);
 }
 
+
+#ifdef ENABLE_SYNCTEX
 static gboolean
 _ev_document_support_synctex (EvDocument *document)
 {
@@ -394,7 +398,6 @@ _ev_document_support_synctex (EvDocument *document)
 	return klass->support_synctex ? klass->support_synctex (document) : FALSE;
 }
 
-#ifdef ENABLE_SYNCTEX
 gboolean
 ev_document_has_synctex (EvDocument *document)
 {

--- a/libview/ev-view-private.h
+++ b/libview/ev-view-private.h
@@ -125,8 +125,9 @@ struct _EvView {
 	GList **find_pages;
 	gint find_result;
 	gboolean jump_to_find_result;
+#ifdef ENABLE_SYNCTEX
 	gboolean highlight_find_results;
-
+#endif
 	EvDocumentModel *model;
 	EvPixbufCache *pixbuf_cache;
 	gsize pixbuf_cache_size;

--- a/libview/ev-view-private.h
+++ b/libview/ev-view-private.h
@@ -125,9 +125,7 @@ struct _EvView {
 	GList **find_pages;
 	gint find_result;
 	gboolean jump_to_find_result;
-#ifdef ENABLE_SYNCTEX
 	gboolean highlight_find_results;
-#endif
 	EvDocumentModel *model;
 	EvPixbufCache *pixbuf_cache;
 	gsize pixbuf_cache_size;

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -177,12 +177,14 @@ static void       ev_view_remove_all                         (EvView            
 static AtkObject *ev_view_get_accessible                     (GtkWidget *widget);
 
 /*** Drawing ***/
+#if ENABLE_SYNCTEX
 static void       highlight_find_results                     (EvView             *view,
 							      cairo_t            *cr,
 							      int                 page);
 static void       highlight_forward_search_results           (EvView             *view,
 							      cairo_t            *cr,
 							      int                 page);
+#endif
 static void       draw_one_page                              (EvView             *view,
 							      gint                page,
 							      cairo_t            *cr,
@@ -4074,8 +4076,10 @@ ev_view_draw (GtkWidget      *widget,
 
 		if (page_ready && should_draw_caret_cursor (view, i))
 			draw_caret_cursor (view, cr);
+#ifdef ENABLE_SYNCTEX
 		if (page_ready && view->find_pages && view->highlight_find_results)
 			highlight_find_results (view, cr, i);
+#endif
 		if (page_ready && EV_IS_DOCUMENT_ANNOTATIONS (view->document))
 			show_annotation_windows (view, i);
 		if (page_ready && view->focused_element)
@@ -5654,6 +5658,7 @@ draw_rubberband (EvView             *view,
 }
 
 
+#ifdef ENABLE_SYNCTEX
 static void
 highlight_find_results (EvView *view, cairo_t *cr, int page)
 {
@@ -5698,6 +5703,7 @@ highlight_forward_search_results (EvView *view, cairo_t *cr, int page)
 	cairo_stroke (cr);
 	cairo_restore (cr);
 }
+#endif
 
 static void
 draw_surface (cairo_t 	      *cr,
@@ -6497,7 +6503,9 @@ ev_view_init (EvView *view)
 	view->page_layout = EV_PAGE_LAYOUT_SINGLE;
 	view->pending_scroll = SCROLL_TO_KEEP_POSITION;
 	view->jump_to_find_result = TRUE;
+#ifdef ENABLE_SYNCTEX
 	view->highlight_find_results = FALSE;
+#endif
 	view->caret_enabled = FALSE;
 	view->cursor_page = 0;
 	view->zoom_center_x = -1;
@@ -7517,7 +7525,9 @@ ev_view_find_search_changed (EvView *view)
 void
 ev_view_find_set_highlight_search (EvView *view, gboolean value)
 {
+#ifdef ENABLE_SYNCTEX
 	view->highlight_find_results = value;
+#endif
 	gtk_widget_queue_draw (GTK_WIDGET (view));
 }
 

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -3210,6 +3210,7 @@ ev_view_remove_annotation (EvView       *view,
         g_object_unref (annot);
 }
 
+#ifdef ENABLE_SYNCTEX
 static gboolean
 ev_view_synctex_backward_search (EvView *view,
 				 gdouble x,
@@ -3235,6 +3236,7 @@ ev_view_synctex_backward_search (EvView *view,
 
 	return FALSE;
 }
+#endif
 
 /* Caret navigation */
 #define CURSOR_ON_MULTIPLIER 2
@@ -4078,8 +4080,10 @@ ev_view_draw (GtkWidget      *widget,
 			show_annotation_windows (view, i);
 		if (page_ready && view->focused_element)
 			draw_focus (view, cr, i, &clip_rect);
+#ifdef ENABLE_SYNCTEX
 		if (page_ready && view->synctex_result)
 			highlight_forward_search_results (view, cr, i);
+#endif
 	}
 
 	if (GTK_WIDGET_CLASS (ev_view_parent_class)->draw)
@@ -4472,9 +4476,10 @@ ev_view_button_press_event (GtkWidget      *widget,
 			EvFormField *field;
 			EvMapping *link;
 			gint page;
-
+#ifdef ENABLE_SYNCTEX
 			if (event->state & GDK_CONTROL_MASK)
 				return ev_view_synctex_backward_search (view, event->x , event->y);
+#endif
 
 			if (EV_IS_SELECTION (view->document) && view->selection_info.selections) {
 				if (event->type == GDK_3BUTTON_PRESS) {
@@ -7522,6 +7527,7 @@ ev_view_find_cancel (EvView *view)
 	view->find_pages = NULL;
 }
 
+#ifdef ENABLE_SYNCTEX
 /*** Synctex ***/
 void
 ev_view_highlight_forward_search (EvView       *view,
@@ -7549,6 +7555,7 @@ ev_view_highlight_forward_search (EvView       *view,
 	ensure_rectangle_is_visible (view, &view_rect);
 	gtk_widget_queue_draw (GTK_WIDGET (view));
 }
+#endif /* ENABLE_SYNCTEX */
 
 /*** Selections ***/
 static gboolean

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -177,10 +177,10 @@ static void       ev_view_remove_all                         (EvView            
 static AtkObject *ev_view_get_accessible                     (GtkWidget *widget);
 
 /*** Drawing ***/
-#if ENABLE_SYNCTEX
 static void       highlight_find_results                     (EvView             *view,
 							      cairo_t            *cr,
 							      int                 page);
+#if ENABLE_SYNCTEX
 static void       highlight_forward_search_results           (EvView             *view,
 							      cairo_t            *cr,
 							      int                 page);
@@ -4076,10 +4076,8 @@ ev_view_draw (GtkWidget      *widget,
 
 		if (page_ready && should_draw_caret_cursor (view, i))
 			draw_caret_cursor (view, cr);
-#ifdef ENABLE_SYNCTEX
 		if (page_ready && view->find_pages && view->highlight_find_results)
 			highlight_find_results (view, cr, i);
-#endif
 		if (page_ready && EV_IS_DOCUMENT_ANNOTATIONS (view->document))
 			show_annotation_windows (view, i);
 		if (page_ready && view->focused_element)
@@ -5627,6 +5625,7 @@ ev_view_style_updated (GtkWidget *widget)
 
 /*** Drawing ***/
 
+
 static void
 draw_rubberband (EvView             *view,
 		 cairo_t            *cr,
@@ -5658,7 +5657,6 @@ draw_rubberband (EvView             *view,
 }
 
 
-#ifdef ENABLE_SYNCTEX
 static void
 highlight_find_results (EvView *view, cairo_t *cr, int page)
 {
@@ -5683,6 +5681,7 @@ highlight_find_results (EvView *view, cairo_t *cr, int page)
         }
 }
 
+#ifdef ENABLE_SYNCTEX
 static void
 highlight_forward_search_results (EvView *view, cairo_t *cr, int page)
 {
@@ -7525,9 +7524,7 @@ ev_view_find_search_changed (EvView *view)
 void
 ev_view_find_set_highlight_search (EvView *view, gboolean value)
 {
-#ifdef ENABLE_SYNCTEX
 	view->highlight_find_results = value;
-#endif
 	gtk_widget_queue_draw (GTK_WIDGET (view));
 }
 

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -7736,6 +7736,8 @@ ev_window_emit_doc_loaded (EvWindow *window)
         ev_atril_window_emit_document_loaded (window->priv->skeleton, window->priv->uri);
 }
 
+
+#ifdef ENABLE_SYNCTEX
 static gboolean
 handle_sync_view_cb (EvAtrilWindow        *object,
                      GDBusMethodInvocation *invocation,
@@ -7756,6 +7758,7 @@ handle_sync_view_cb (EvAtrilWindow        *object,
 
 	return TRUE;
 }
+#endif
 #endif /* ENABLE_DBUS */
 
 static gboolean
@@ -7816,9 +7819,11 @@ ev_window_init (EvWindow *ev_window)
                                                       ev_window->priv->dbus_object_path,
                                                       &error)) {
                         ev_window->priv->skeleton = skeleton;
+#ifdef ENABLE_SYNCTEX
                         g_signal_connect (skeleton, "handle-sync-view",
                                           G_CALLBACK (handle_sync_view_cb),
                                           ev_window);
+#endif
                 } else {
                         g_printerr ("Failed to register bus object %s: %s\n",
 			            ev_window->priv->dbus_object_path, error->message);


### PR DESCRIPTION
This is still work in progress. The code still needs to be disabled
in the C code.
Comments are welcome, I am a total idiot when it comes to autotools :-P.