### PR TITLE
dviread: ‘inline’ is not at beginning of declaration

### DIFF
--- a/backend/dvi/mdvi-lib/dviread.c
+++ b/backend/dvi/mdvi-lib/dviread.c
@@ -1101,7 +1101,7 @@ again:
 	return 0;
 }
 
-static int inline move_vertical(DviContext *dvi, int amount)
+inline static int move_vertical(DviContext *dvi, int amount)
 {
 	int	rvv;
 
@@ -1124,7 +1124,7 @@ static int inline move_vertical(DviContext *dvi, int amount)
 	}
 }
 
-static int inline move_horizontal(DviContext *dvi, int amount)
+inline static int move_horizontal(DviContext *dvi, int amount)
 {
 	int	rhh;
 
@@ -1147,7 +1147,7 @@ static int inline move_horizontal(DviContext *dvi, int amount)
 	}
 }
 
-static void inline fix_after_horizontal(DviContext *dvi)
+inline static void fix_after_horizontal(DviContext *dvi)
 {
 	int	rhh;
 


### PR DESCRIPTION
```
dviread.c:1104:1: warning: ‘inline’ is not at beginning of declaration [-Wold-style-declaration]
 1104 | static int inline move_vertical(DviContext *dvi, int amount)
      | ^~~~~~

dviread.c:1127:1: warning: ‘inline’ is not at beginning of declaration [-Wold-style-declaration]
 1127 | static int inline move_horizontal(DviContext *dvi, int amount)
      | ^~~~~~

dviread.c:1150:1: warning: ‘inline’ is not at beginning of declaration [-Wold-style-declaration]
 1150 | static void inline fix_after_horizontal(DviContext *dvi)
      | ^~~~~~
```