### PR TITLE
Use int64_t for g_date_time_to_unix even word size is 32-bit wide

### DIFF
--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -2190,7 +2190,7 @@ set_uri_mtime (GFile        *source,
 	       EvWindow     *ev_window)
 {
 	GFileInfo *info;
-	gint      utime = -1;
+	gint64     utime = -1;
 
 	info = g_file_query_info_finish (source, async_result, NULL);
 	if (info) {


### PR DESCRIPTION
See https://github.com/mate-desktop/atril/pull/434#discussion_r379825415