### PR TITLE
Travis CI: build with --enable-cxx-warnings=maximum

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -151,7 +151,7 @@ before_scripts:
 
 build_scripts:
   - ./autogen.sh
-  - scan-build $CHECKERS ./configure --enable-compile-warnings=maximum
+  - scan-build $CHECKERS ./configure --enable-compile-warnings=maximum --enable-cxx-warnings=maximum
   - if [ $CPU_COUNT -gt 1 ]; then
   -     scan-build $CHECKERS --keep-cc -o html-report make -j $CPU_COUNT
   - else

--- a/backend/epub/Makefile.am
+++ b/backend/epub/Makefile.am
@@ -7,8 +7,8 @@ AM_CPPFLAGS = 		       			\
 	-DMATELOCALEDIR=\"$(datadir)/locale\"	\
 	-DATRIL_COMPILATION			\
 	$(BACKEND_CFLAGS)			\
-	$(WARN_CXXFLAGS)			\
-	$(EPUB_CFLAGS)			\
+	$(WARN_CFLAGS)				\
+	$(EPUB_CFLAGS)				\
 	$(DISABLE_DEPRECATED)
 
 backend_LTLIBRARIES = libepubdocument.la


### PR DESCRIPTION
We can see more build warnings in atril with this change