### PR TITLE
ev-window/epub-document: remove unused functions

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -942,17 +942,6 @@ link_present_on_page(const gchar* link,const gchar *page_uri)
 	}
 }
 
-static void
-check_add_page_numbers(linknode *listdata, contentListNode *comparenode)
-{
-    if (link_present_on_page(listdata->pagelink, comparenode->value)) {
-		listdata->page = comparenode->index - 1;
-	}
-    if (listdata->children != NULL) {
-        g_list_foreach(listdata->children,(GFunc)check_add_page_numbers,comparenode);
-    }
-}
-
 static GList*
 setup_document_content_list(const gchar* content_uri, GError** error,gchar *documentdir)
 {

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -6375,20 +6375,6 @@ ev_window_dispose (GObject *object)
 	G_OBJECT_CLASS (ev_window_parent_class)->dispose (object);
 }
 
-static void
-menubar_deactivate_cb (GtkWidget *menubar,
-		       EvWindow  *window)
-{
-	g_signal_handlers_disconnect_by_func (menubar,
-					      G_CALLBACK (menubar_deactivate_cb),
-					      window);
-
-	gtk_menu_shell_deselect (GTK_MENU_SHELL (menubar));
-
-	update_chrome_visibility (window);
-}
-
-
 /*
  * GtkWindow catches keybindings for the menu items _before_ passing them to
  * the focused widget. This is unfortunate and means that pressing Ctrl+a,


### PR DESCRIPTION
Fixes the build warnings:

```
ev-window.c:6379:1: warning: function 'menubar_deactivate_cb' is not needed and will not be emitted [-Wunneeded-internal-declaration]
menubar_deactivate_cb (GtkWidget *menubar,
^

epub-document.c:946:1: warning: function 'check_add_page_numbers' is not needed and will not be emitted [-Wunneeded-internal-declaration]
check_add_page_numbers(linknode *listdata, contentListNode *comparenode)
^
```