### PR TITLE
epub-document: Remove unused-variable warning

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -499,7 +499,7 @@ xml_get_pointer_to_node(xmlChar* parserfor,
                         xmlChar*  attributename,
                         xmlChar* attributevalue )
 {
-    xmlNodePtr topchild,children ;
+    xmlNodePtr topchild;
 
     xmlretval = NULL ;
 
@@ -1330,7 +1330,6 @@ epub_document_get_info(EvDocument *document)
 	gchar* infofile ;
 	xmlNodePtr metanode ;
 	GString* buffer ;
-	gchar* archive_dir = epub_document->tmp_archive_dir;
 
 	GString* containerpath = g_string_new(epub_document->tmp_archive_dir);
 	g_string_append_printf(containerpath,"/META-INF/container.xml");
@@ -1506,10 +1505,10 @@ add_night_sheet(contentListNode *listdata,gchar *sheet)
     set_xml_root_node(NULL);
     xmlNodePtr head = xml_get_pointer_to_node((xmlChar*)"head",NULL,NULL);
 
-    xmlNodePtr link = xmlNewTextChild(head,NULL,(xmlChar*)"link",NULL);
-    xmlAttrPtr href = xmlNewProp(link,(xmlChar*)"href",(xmlChar*)sheeturi);
-    xmlAttrPtr rel = xmlNewProp(link,(xmlChar*)"rel",(xmlChar*)"alternate stylesheet");
-    xmlAttrPtr class =  xmlNewProp(link,(xmlChar*)"class",(xmlChar*)"night");
+    xmlNodePtr link = xmlNewTextChild (head, NULL, (xmlChar*) "link", NULL);
+    xmlNewProp (link, (xmlChar*) "href", (xmlChar*) sheeturi);
+    xmlNewProp (link, (xmlChar*) "rel", (xmlChar*) "alternate stylesheet");
+    xmlNewProp (link, (xmlChar*) "class", (xmlChar*) "night");
 
     xmlSaveFormatFile (listdata->value, xmldocument, 0);
     xml_free_doc();
@@ -1657,7 +1656,6 @@ static void
 epub_document_add_mathJax(gchar* containeruri,gchar* documentdir)
 {
 	gchar *containerfilename= g_filename_from_uri(containeruri,NULL,NULL);
-	const gchar *backenddir = ev_backends_manager_get_backends_dir();
 	GString *mathjaxdir = g_string_new("/usr/share/javascript/mathjax");
 
 	gchar *mathjaxref = g_filename_to_uri(mathjaxdir->str,NULL,NULL);


### PR DESCRIPTION
```
epub-document.c:502:25: warning: unused variable ‘children’ [-Wunused-variable]
  502 |     xmlNodePtr topchild,children ;
      |                         ^~~~~~~~
--
epub-document.c:1333:9: warning: unused variable ‘archive_dir’ [-Wunused-variable]
 1333 |  gchar* archive_dir = epub_document->tmp_archive_dir;
      |         ^~~~~~~~~~~
--
epub-document.c:1512:16: warning: unused variable ‘class’ [-Wunused-variable]
 1512 |     xmlAttrPtr class =  xmlNewProp(link,(xmlChar*)"class",(xmlChar*)"night");
      |                ^~~~~
epub-document.c:1511:16: warning: unused variable ‘rel’ [-Wunused-variable]
 1511 |     xmlAttrPtr rel = xmlNewProp(link,(xmlChar*)"rel",(xmlChar*)"alternate stylesheet");
      |                ^~~
epub-document.c:1510:16: warning: unused variable ‘href’ [-Wunused-variable]
 1510 |     xmlAttrPtr href = xmlNewProp(link,(xmlChar*)"href",(xmlChar*)sheeturi);
      |                ^~~~
--
epub-document.c:1660:15: warning: unused variable ‘backenddir’ [-Wunused-variable]
 1660 |  const gchar *backenddir = ev_backends_manager_get_backends_dir();
      |               ^~~~~~~~~~
```