### PR TITLE
Remove strict-prototypes warning

### DIFF
--- a/backend/dvi/mdvi-lib/fontmap.c
+++ b/backend/dvi/mdvi-lib/fontmap.c
@@ -645,7 +645,7 @@ void	mdvi_install_fontmap(DviFontMapEnt *head)
 	}
 }
 
-static void init_static_encoding()
+static void init_static_encoding(void)
 {
 	DviEncoding	*encoding;
 	int	i;

--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -435,7 +435,7 @@ xml_get_data_from_node      (xmlNodePtr node,
                              xmlChar* attributename);
 
 static void
-xml_free_doc();
+xml_free_doc                (void);
 
 static void
 free_tree_nodes             (gpointer data);


### PR DESCRIPTION
```
epub-document.c:438:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  438 | xml_free_doc();
      | ^~~~~~~~~~~~
epub-document.c:575:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  575 | xml_free_doc()
      | ^~~~~~~~~~~~
--
fontmap.c:648:13: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  648 | static void init_static_encoding()
      |             ^~~~~~~~~~~~~~~~~~~~
```