### PR TITLE
Fix cppcheck [knownConditionTrueFalse] warnings

### DIFF
--- a/backend/comics/comics-document.c
+++ b/backend/comics/comics-document.c
@@ -764,7 +764,7 @@ comics_document_render_pixbuf (EvDocument      *document,
 			if (bytes > 0) {
 				gdk_pixbuf_loader_write (loader, buf, bytes,
 				NULL);
-			} else if (bytes <= 0) {
+			} else {
 				close (outpipe);
 				gdk_pixbuf_loader_close (loader, NULL);
 				outpipe = -1;

--- a/backend/epub/minizip/unzip.c
+++ b/backend/epub/minizip/unzip.c
@@ -119,9 +119,6 @@
 #define SIZEZIPLOCALHEADER (0x1e)
 
 
-const char unz_copyright[] =
-   " unzip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
-
 /* unz_file_info_interntal contain internal info about a file in zipfile*/
 typedef struct unz_file_info64_internal_s
 {
@@ -599,9 +596,6 @@ local unzFile unzOpenInternal (const void *path,
                                    (same than number_entry on nospan) */
 
     int err=UNZ_OK;
-
-    if (unz_copyright[0]!=' ')
-        return NULL;
 
     us.z_filefunc.zseek32_file = NULL;
     us.z_filefunc.ztell32_file = NULL;

--- a/properties/ev-properties-view.c
+++ b/properties/ev-properties-view.c
@@ -194,7 +194,7 @@ set_property (EvPropertiesView *properties,
 		gtk_label_set_markup (GTK_LABEL (label), markup);
 		g_free (markup);
 	} else {
-		valid_text = make_valid_utf8 (text ? text : "");
+		valid_text = make_valid_utf8 (text);
 		gtk_label_set_text (GTK_LABEL (label), valid_text);
 		g_free (valid_text);
 	}

--- a/shell/ev-sidebar-thumbnails.c
+++ b/shell/ev-sidebar-thumbnails.c
@@ -581,8 +581,6 @@ ev_sidebar_thumbnails_fill_model (EvSidebarThumbnails *sidebar_thumbnails)
 	EvSidebarThumbnailsPrivate *priv = sidebar_thumbnails->priv;
 	GtkTreeIter iter;
 	int i;
-	gint prev_width = -1;
-	gint prev_height = -1;
 
 	for (i = 0; i < sidebar_thumbnails->priv->n_pages; i++) {
 		gchar     *page_label;
@@ -593,16 +591,11 @@ ev_sidebar_thumbnails_fill_model (EvSidebarThumbnails *sidebar_thumbnails)
 		page_label = ev_document_get_page_label (priv->document, i);
 		page_string = g_markup_printf_escaped ("<i>%s</i>", page_label);
 		ev_thumbnails_size_cache_get_size (sidebar_thumbnails->priv->size_cache, i,
-						  sidebar_thumbnails->priv->rotation,
-						  &width, &height);
-		if (!loading_icon || (width != prev_width && height != prev_height)) {
-			loading_icon =
-				ev_sidebar_thumbnails_get_loading_icon (sidebar_thumbnails,
-									width, height);
-		}
+						   sidebar_thumbnails->priv->rotation,
+						   &width, &height);
 
-		prev_width = width;
-		prev_height = height;
+		loading_icon = ev_sidebar_thumbnails_get_loading_icon (sidebar_thumbnails,
+								       width, height);
 
 		gtk_list_store_append (priv->list_store, &iter);
 		gtk_list_store_set (priv->list_store, &iter,

--- a/shell/main.c
+++ b/shell/main.c
@@ -80,10 +80,11 @@ static const GOptionEntry goption_options[] =
 static gboolean
 launch_previewer (void)
 {
-	GString *cmd_str;
-	gchar   *cmd;
-	gboolean retval = FALSE;
-	GError  *error = NULL;
+	GString  *cmd_str;
+	gchar    *cmd;
+	GAppInfo *app;
+	gboolean  retval = FALSE;
+	GError   *error = NULL;
 
 	/* Rebuild the command line, ignoring options
 	 * not supported by the previewer and taking only
@@ -112,15 +113,11 @@ launch_previewer (void)
 
 	cmd = g_string_free (cmd_str, FALSE);
 
-	if (!error) {
-		GAppInfo *app;
+	app = g_app_info_create_from_commandline (cmd, NULL, 0, &error);
 
-		app = g_app_info_create_from_commandline (cmd, NULL, 0, &error);
-
-		if (app != NULL) {
-			retval = g_app_info_launch (app, NULL, NULL, &error);
-			g_object_unref (app);
-		}
+	if (app != NULL) {
+		retval = g_app_info_launch (app, NULL, NULL, &error);
+		g_object_unref (app);
 	}
 
 	if (error) {


### PR DESCRIPTION
Fixes the warnings:

```
backend/comics/comics-document.c:767:21: style: Condition 'bytes<=0' is always true [knownConditionTrueFalse]

backend/epub/minizip/unzip.c:603:25: style: Condition 'unz_copyright[0]!=' '' is always false [knownConditionTrueFalse]

properties/ev-properties-view.c:197:33: style: Condition 'text' is always true [knownConditionTrueFalse]

shell/ev-sidebar-thumbnails.c:598:7: style: Condition '!loading_icon' is always true [knownConditionTrueFalse]

shell/main.c:115:6: style: Condition '!error' is always true [knownConditionTrueFalse]
```