### PR TITLE
djvu-text-page: Fix cppcheck [clarifyCalculation] warnings

### DIFF
--- a/backend/djvu/djvu-text-page.c
+++ b/backend/djvu/djvu-text-page.c
@@ -43,8 +43,8 @@ djvu_text_page_selection_process (DjvuTextPage *page,
 		char *token_text = (char *) miniexp_to_str (miniexp_nth (5, p));
 		if (page->text) {
 			char *new_text =
-			    g_strjoin (delimit & 2 ? "\n" :
-			    	       delimit & 1 ? " " : NULL,
+			    g_strjoin ((delimit & 2) ? "\n" :
+			    	       (delimit & 1) ? " " : NULL,
 				       page->text, token_text,
 				       NULL);
 			g_free (page->text);


### PR DESCRIPTION
Fixes the warnings:

```
backend/djvu/djvu-text-page.c:46:31: style: Clarify calculation precedence for '&' and '?'. [clarifyCalculation]
       g_strjoin (delimit & 2 ? "\n" :
                              ^

backend/djvu/djvu-text-page.c:47:28: style: Clarify calculation precedence for '&' and '?'. [clarifyCalculation]
               delimit & 1 ? " " : NULL,
                           ^
```

https://en.cppreference.com/w/c/language/operator_precedence