### PR TITLE
ev-poppler: remove warning about no previous declaration

### DIFF
--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -1380,7 +1380,7 @@ pdf_document_images_get_image_mapping (EvDocumentImages *document_images,
 	return ev_mapping_list_new (page->index, g_list_reverse (retval), (GDestroyNotify)g_object_unref);
 }
 
-GdkPixbuf *
+static GdkPixbuf *
 pdf_document_images_get_image (EvDocumentImages *document_images,
 			       EvImage          *image)
 {


### PR DESCRIPTION
```
ev-poppler.cc:1384:1: warning: no previous declaration for 'GdkPixbuf* pdf_document_images_get_image(EvDocumentImages*, EvImage*)' [-Wmissing-declarations]
 1384 | pdf_document_images_get_image (EvDocumentImages *document_images,
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```