### PR TITLE
Make sure attachments window fills entire sidebar

### DIFF
--- a/shell/ev-sidebar-attachments.c
+++ b/shell/ev-sidebar-attachments.c
@@ -565,7 +565,7 @@ ev_sidebar_attachments_init (EvSidebarAttachments *ev_attachbar)
 	gtk_container_add (GTK_CONTAINER (swindow),
 			   ev_attachbar->priv->icon_view);
 
-        gtk_box_pack_start (GTK_BOX (ev_attachbar), swindow, TRUE, TRUE, 0);
+	gtk_box_pack_start (GTK_BOX (ev_attachbar), swindow, TRUE, TRUE, 0);
 	gtk_container_add (GTK_CONTAINER (ev_attachbar),
 			   swindow);
 	gtk_widget_show_all (GTK_WIDGET (ev_attachbar));

--- a/shell/ev-sidebar-attachments.c
+++ b/shell/ev-sidebar-attachments.c
@@ -565,6 +565,7 @@ ev_sidebar_attachments_init (EvSidebarAttachments *ev_attachbar)
 	gtk_container_add (GTK_CONTAINER (swindow),
 			   ev_attachbar->priv->icon_view);
 
+        gtk_box_pack_start (GTK_BOX (ev_attachbar), swindow, TRUE, TRUE, 0);
 	gtk_container_add (GTK_CONTAINER (ev_attachbar),
 			   swindow);
 	gtk_widget_show_all (GTK_WIDGET (ev_attachbar));


### PR DESCRIPTION
When looking at a document that has attachments, the attachment window only opens up a very small portion of the sidebar up at the top.  Looking at the source code for another document viewer from another project *cough* evince *cough* I found you needed to have a call to gtk_box_pack_start () in order to have it fill out the sidebar.  Here's a pull request that fixes the issue.  Tested on Debian 10, works.