### PR TITLE
ev-pixbuf-cache: Remove -Wtype-limits warnings

### DIFF
--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -641,14 +641,14 @@ get_selection_colors (EvView *view, GdkColor *text, GdkColor *base)
         _ev_view_get_selection_colors (view, &bg, &fg);
 
         text->pixel = 0;
-        text->red = CLAMP ((guint) (fg.red * 65535), 0, 65535);
-        text->green = CLAMP ((guint) (fg.green * 65535), 0, 65535);
-        text->blue = CLAMP ((guint) (fg.blue * 65535), 0, 65535);
+        text->red = (guint16) (fg.red * G_MAXUINT16);
+        text->green = (guint16) (fg.green * G_MAXUINT16);
+        text->blue = (guint16) (fg.blue * G_MAXUINT16);
 
         base->pixel = 0;
-        base->red = CLAMP ((guint) (bg.red * 65535), 0, 65535);
-        base->green = CLAMP ((guint) (bg.green * 65535), 0, 65535);
-        base->blue = CLAMP ((guint) (bg.blue * 65535), 0, 65535);
+        base->red = (guint16) (bg.red * G_MAXUINT16);
+        base->green = (guint16) (bg.green * G_MAXUINT16);
+        base->blue = (guint16) (bg.blue * G_MAXUINT16);
 }
 
 static void


### PR DESCRIPTION
Test: select any text in a document
```
ev-pixbuf-cache.c: In function 'get_selection_colors':
/usr/include/glib-2.0/glib/gmacros.h:811:63: warning: comparison of unsigned expression in '< 0' is always false [-Wtype-limits]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                                                               ^
ev-pixbuf-cache.c:644:21: note: in expansion of macro 'CLAMP'
  644 |         text->red = CLAMP ((guint) (fg.red * 65535), 0, 65535);
      |                     ^~~~~
/usr/include/glib-2.0/glib/gmacros.h:811:30: warning: conversion from 'unsigned int' to 'guint16' {aka 'short unsigned int'} may change value [-Wconversion]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                              ^
ev-pixbuf-cache.c:644:21: note: in expansion of macro 'CLAMP'
  644 |         text->red = CLAMP ((guint) (fg.red * 65535), 0, 65535);
      |                     ^~~~~
/usr/include/glib-2.0/glib/gmacros.h:811:63: warning: comparison of unsigned expression in '< 0' is always false [-Wtype-limits]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                                                               ^
ev-pixbuf-cache.c:645:23: note: in expansion of macro 'CLAMP'
  645 |         text->green = CLAMP ((guint) (fg.green * 65535), 0, 65535);
      |                       ^~~~~
/usr/include/glib-2.0/glib/gmacros.h:811:30: warning: conversion from 'unsigned int' to 'guint16' {aka 'short unsigned int'} may change value [-Wconversion]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                              ^
ev-pixbuf-cache.c:645:23: note: in expansion of macro 'CLAMP'
  645 |         text->green = CLAMP ((guint) (fg.green * 65535), 0, 65535);
      |                       ^~~~~
/usr/include/glib-2.0/glib/gmacros.h:811:63: warning: comparison of unsigned expression in '< 0' is always false [-Wtype-limits]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                                                               ^
ev-pixbuf-cache.c:646:22: note: in expansion of macro 'CLAMP'
  646 |         text->blue = CLAMP ((guint) (fg.blue * 65535), 0, 65535);
      |                      ^~~~~
/usr/include/glib-2.0/glib/gmacros.h:811:30: warning: conversion from 'unsigned int' to 'guint16' {aka 'short unsigned int'} may change value [-Wconversion]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                              ^
ev-pixbuf-cache.c:646:22: note: in expansion of macro 'CLAMP'
  646 |         text->blue = CLAMP ((guint) (fg.blue * 65535), 0, 65535);
      |                      ^~~~~
/usr/include/glib-2.0/glib/gmacros.h:811:63: warning: comparison of unsigned expression in '< 0' is always false [-Wtype-limits]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                                                               ^
ev-pixbuf-cache.c:649:21: note: in expansion of macro 'CLAMP'
  649 |         base->red = CLAMP ((guint) (bg.red * 65535), 0, 65535);
      |                     ^~~~~
/usr/include/glib-2.0/glib/gmacros.h:811:30: warning: conversion from 'unsigned int' to 'guint16' {aka 'short unsigned int'} may change value [-Wconversion]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                              ^
ev-pixbuf-cache.c:649:21: note: in expansion of macro 'CLAMP'
  649 |         base->red = CLAMP ((guint) (bg.red * 65535), 0, 65535);
      |                     ^~~~~
/usr/include/glib-2.0/glib/gmacros.h:811:63: warning: comparison of unsigned expression in '< 0' is always false [-Wtype-limits]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                                                               ^
ev-pixbuf-cache.c:650:23: note: in expansion of macro 'CLAMP'
  650 |         base->green = CLAMP ((guint) (bg.green * 65535), 0, 65535);
      |                       ^~~~~
/usr/include/glib-2.0/glib/gmacros.h:811:30: warning: conversion from 'unsigned int' to 'guint16' {aka 'short unsigned int'} may change value [-Wconversion]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                              ^
ev-pixbuf-cache.c:650:23: note: in expansion of macro 'CLAMP'
  650 |         base->green = CLAMP ((guint) (bg.green * 65535), 0, 65535);
      |                       ^~~~~
/usr/include/glib-2.0/glib/gmacros.h:811:63: warning: comparison of unsigned expression in '< 0' is always false [-Wtype-limits]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                                                               ^
ev-pixbuf-cache.c:651:22: note: in expansion of macro 'CLAMP'
  651 |         base->blue = CLAMP ((guint) (bg.blue * 65535), 0, 65535);
      |                      ^~~~~
/usr/include/glib-2.0/glib/gmacros.h:811:30: warning: conversion from 'unsigned int' to 'guint16' {aka 'short unsigned int'} may change value [-Wconversion]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                              ^
ev-pixbuf-cache.c:651:22: note: in expansion of macro 'CLAMP'
  651 |         base->blue = CLAMP ((guint) (bg.blue * 65535), 0, 65535);
      |                      ^~~~~
```
![cast](https://user-images.githubusercontent.com/10171411/87570277-ab6c9400-c6c8-11ea-816e-6e84fe8db1ce.png)
