### PR TITLE
ev-window: fix interval (guint milliseconds) in g_timeout_add_full

### DIFF
--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -902,7 +902,7 @@ ev_window_show_loading_message (EvWindow *window)
 	if (window->priv->loading_message_timeout)
 		return;
 	window->priv->loading_message_timeout =
-		g_timeout_add_full (G_PRIORITY_LOW, 0.5, (GSourceFunc)show_loading_message_cb, window, NULL);
+		g_timeout_add_full (G_PRIORITY_LOW, 500, (GSourceFunc)show_loading_message_cb, window, NULL);
 }
 
 static void


### PR DESCRIPTION
```
ev-view-presentation.c:255:28: warning: conversion from 'gdouble' {aka 'double'} to 'guint' {aka 'unsigned int'} may change value [-Wfloat-conversion]
  255 |     g_timeout_add_seconds (duration,
      |                            ^~~~~~~~
```