### PR TITLE
Remove -Wfloat-conversion warnings

### DIFF
--- a/backend/comics/comics-document.c
+++ b/backend/comics/comics-document.c
@@ -785,9 +785,10 @@ comics_document_render_pixbuf (EvDocument      *document,
 		gdk_pixbuf_get_file_info (filename, &width, &height);
 
 		tmp_pixbuf =
-			gdk_pixbuf_new_from_file_at_size (
-				    filename, width * (rc->scale) + 0.5,
-				    height * (rc->scale) + 0.5, NULL);
+			gdk_pixbuf_new_from_file_at_size (filename,
+			                                  (int)((double)width * (rc->scale)),
+			                                  (int)((double)height * (rc->scale)),
+			                                  NULL);
 		rotated_pixbuf =
 			gdk_pixbuf_rotate_simple (tmp_pixbuf,
 						  360 - rc->rotation);
@@ -818,8 +819,8 @@ render_pixbuf_size_prepared_cb (GdkPixbufLoader *loader,
 				gpointer         data)
 {
 	double *scale = data;
-	int w = (width  * (*scale) + 0.5);
-	int h = (height * (*scale) + 0.5);
+	int w = (int)((double)width  * (*scale));
+	int h = (int)((double)height * (*scale));
 
 	gdk_pixbuf_loader_set_size (loader, w, h);
 }

--- a/backend/djvu/djvu-document.c
+++ b/backend/djvu/djvu-document.c
@@ -329,8 +329,8 @@ djvu_document_render (EvDocument      *document,
 	while (!ddjvu_page_decoding_done (d_page))
 		djvu_handle_events(djvu_document, TRUE, NULL);
 
-	page_width = ddjvu_page_get_width (d_page) * rc->scale * SCALE_FACTOR + 0.5;
-	page_height = ddjvu_page_get_height (d_page) * rc->scale * SCALE_FACTOR + 0.5;
+	page_width = ddjvu_page_get_width (d_page) * rc->scale * SCALE_FACTOR;
+	page_height = ddjvu_page_get_height (d_page) * rc->scale * SCALE_FACTOR;
 
 	switch (rc->rotation) {
 	        case 90:
@@ -356,14 +356,15 @@ djvu_document_render (EvDocument      *document,
 	}
 
 	surface = cairo_image_surface_create (CAIRO_FORMAT_RGB24,
-					      page_width, page_height);
+	                                      (int)page_width,
+	                                      (int)page_height);
 	rowstride = cairo_image_surface_get_stride (surface);
 	pixels = (gchar *)cairo_image_surface_get_data (surface);
 
 	prect.x = 0;
 	prect.y = 0;
-	prect.w = page_width;
-	prect.h = page_height;
+	prect.w = (unsigned int)page_width;
+	prect.h = (unsigned int)page_height;
 	rrect = prect;
 
 	ddjvu_page_set_rotation (d_page, rotation);

--- a/backend/dvi/cairo-device.c
+++ b/backend/dvi/cairo-device.c
@@ -216,10 +216,10 @@ dvi_cairo_alloc_colors (void  *device_data,
 			pow ((double)i / n, 1 / gamma) :
 			1 - pow ((double)(n - i) / n, -gamma);
 
-		color.red = frac * color_fg.red;
-		color.green = frac * color_fg.green;
-		color.blue = frac * color_fg.blue;
-		alpha = frac * 0xFF;
+		color.red = (guint16)(frac * color_fg.red);
+		color.green = (guint16)(frac * color_fg.green);
+		color.blue = (guint16)(frac * color_fg.blue);
+		alpha = (unsigned int)(frac * 0xFF);
 
 		pixels[i] = (alpha << 24) + (color.red << 16) + (color.green << 8) + color.blue;
 	}
@@ -332,8 +332,8 @@ mdvi_cairo_device_render (DviContext* dvi)
 	if (cairo_device->cr)
 		cairo_destroy (cairo_device->cr);
 
-	page_width = dvi->dvi_page_w * dvi->params.conv + 2 * cairo_device->xmargin;
-	page_height = dvi->dvi_page_h * dvi->params.vconv + 2 * cairo_device->ymargin;
+	page_width = (int)(dvi->dvi_page_w * dvi->params.conv + 2 * cairo_device->xmargin);
+	page_height = (int)(dvi->dvi_page_h * dvi->params.vconv + 2 * cairo_device->ymargin);
 
 	surface = cairo_image_surface_create (CAIRO_FORMAT_ARGB32,
                                               page_width, page_height);

--- a/backend/dvi/dvi-document.c
+++ b/backend/dvi/dvi-document.c
@@ -177,10 +177,10 @@ dvi_document_render (EvDocument      *document,
 			 (int)((dvi_document->params->hshrink - 1) / rc->scale) + 1,
 			 (int)((dvi_document->params->vshrink - 1) / rc->scale) + 1);
 
-	required_width = dvi_document->base_width * rc->scale + 0.5;
-	required_height = dvi_document->base_height * rc->scale + 0.5;
-	proposed_width = dvi_document->context->dvi_page_w * dvi_document->context->params.conv;
-	proposed_height = dvi_document->context->dvi_page_h * dvi_document->context->params.vconv;
+	required_width = (int)(dvi_document->base_width * rc->scale);
+	required_height = (int)(dvi_document->base_height * rc->scale);
+	proposed_width = (int)(dvi_document->context->dvi_page_w * dvi_document->context->params.conv);
+	proposed_height = (int)(dvi_document->context->dvi_page_h * dvi_document->context->params.vconv);
 
 	if (required_width >= proposed_width)
 	    xmargin = (required_width - proposed_width) / 2;
@@ -295,11 +295,11 @@ dvi_document_thumbnails_get_thumbnail (EvDocumentThumbnails *document,
 	mdvi_setpage (dvi_document->context, rc->page->index);
 
 	mdvi_set_shrink (dvi_document->context,
-			  (int)dvi_document->base_width * dvi_document->params->hshrink / thumb_width,
-			  (int)dvi_document->base_height * dvi_document->params->vshrink / thumb_height);
+			  (int)(dvi_document->base_width * dvi_document->params->hshrink / thumb_width),
+			  (int)(dvi_document->base_height * dvi_document->params->vshrink / thumb_height));
 
-	proposed_width = dvi_document->context->dvi_page_w * dvi_document->context->params.conv;
-	proposed_height = dvi_document->context->dvi_page_h * dvi_document->context->params.vconv;
+	proposed_width = (int)(dvi_document->context->dvi_page_w * dvi_document->context->params.conv);
+	proposed_height = (int)(dvi_document->context->dvi_page_h * dvi_document->context->params.vconv);
 
 	if (border) {
 	 	mdvi_cairo_device_set_margins (&dvi_document->context->device,
@@ -422,15 +422,15 @@ dvi_document_file_exporter_iface_init (EvFileExporterInterface *iface)
 #define RGB2ULONG(r,g,b) ((0xFF<<24)|(r<<16)|(g<<8)|(b))
 
 static gboolean
-hsb2rgb (float h, float s, float v, guchar *red, guchar *green, guchar *blue)
+hsb2rgb (gdouble h, gdouble s, gdouble v, guchar *red, guchar *green, guchar *blue)
 {
-        float f, p, q, t, r, g, b;
+        gdouble f, p, q, t, r, g, b;
         int i;
 
         s /= 100;
         v /= 100;
         h /= 60;
-        i = floor (h);
+        i = (int)h;
         if (i == 6)
                 i = 0;
         else if ((i > 6) || (i < 0))
@@ -466,9 +466,9 @@ hsb2rgb (float h, float s, float v, guchar *red, guchar *green, guchar *blue)
 		b = q;
 	}
 
-        *red   = (guchar)floor(r * 255.0);
-        *green = (guchar)floor(g * 255.0);
-        *blue  = (guchar)floor(b * 255.0);
+        *red   = (guchar)(r * 255.0);
+        *green = (guchar)(g * 255.0);
+        *blue  = (guchar)(b * 255.0);
 
         return TRUE;
 }
@@ -507,9 +507,9 @@ dvi_document_do_color_special (DviContext *dvi, const char *prefix, const char *
 
 			parse_color (tmp + 4, rgb, 3);
 
-                        red = 255 * rgb[0];
-                        green = 255 * rgb[1];
-                        blue = 255 * rgb[2];
+                        red   = (guchar)(rgb[0] * 255.0);
+                        green = (guchar)(rgb[1] * 255.0);
+                        blue  = (guchar)(rgb[2] * 255.0);
 
                         mdvi_push_color (dvi, RGB2ULONG (red, green, blue), 0xFFFFFFFF);
                 } else if (!strncmp ("hsb", tmp, 4)) {
@@ -537,9 +537,9 @@ dvi_document_do_color_special (DviContext *dvi, const char *prefix, const char *
                         if (b < 0.0)
                                 b = 0.0;
 
-			red = r * 255 + 0.5;
-			green = g * 255 + 0.5;
-			blue = b * 255 + 0.5;
+			red   = (guchar)(r * 255.0);
+			green = (guchar)(g * 255.0);
+			blue  = (guchar)(b * 255.0);
 
                         mdvi_push_color (dvi, RGB2ULONG (red, green, blue), 0xFFFFFFFF);
 		} else if (!strncmp ("gray ", tmp, 5)) {
@@ -548,7 +548,7 @@ dvi_document_do_color_special (DviContext *dvi, const char *prefix, const char *
 
 			parse_color (tmp + 5, &gray, 1);
 
-			rgb = gray * 255 + 0.5;
+			rgb = (guchar)(gray * 255.0);
 
 			mdvi_push_color (dvi, RGB2ULONG (rgb, rgb, rgb), 0xFFFFFFFF);
                 } else {
@@ -557,9 +557,9 @@ dvi_document_do_color_special (DviContext *dvi, const char *prefix, const char *
                         if (gdk_color_parse (tmp, &color)) {
 				guchar red, green, blue;
 
-				red = color.red * 255 / 65535.;
-				green = color.green * 255 / 65535.;
-				blue = color.blue * 255 / 65535.;
+				red   = (guchar)(color.red   * 255.0 / 65535.0);
+				green = (guchar)(color.green * 255.0 / 65535.0);
+				blue  = (guchar)(color.blue  * 255.0 / 65535.0);
 
                                 mdvi_push_color (dvi, RGB2ULONG (red, green, blue), 0xFFFFFFFF);
 			}

--- a/backend/ps/ev-spectre.c
+++ b/backend/ps/ev-spectre.c
@@ -267,8 +267,8 @@ ps_document_get_info (EvDocument *document)
 	info->format = g_strdup (spectre_document_get_format (ps->doc));
 	info->creator = g_strdup (creator ? creator : spectre_document_get_for (ps->doc));
 	info->n_pages = spectre_document_get_n_pages (ps->doc);
-	info->paper_width  = width / 72.0f * 25.4f;
-	info->paper_height = height / 72.0f * 25.4f;
+	info->paper_width  = (float)width / 72.0f * 25.4f;
+	info->paper_height = (float)height / 72.0f * 25.4f;
 
 	return info;
 }

--- a/backend/tiff/tiff-document.c
+++ b/backend/tiff/tiff-document.c
@@ -170,8 +170,8 @@ tiff_document_get_resolution (TiffDocument *tiff_document,
 	    TIFFGetField (tiff_document->tiff, TIFFTAG_YRESOLUTION, &y)) {
 		if (TIFFGetFieldDefaulted (tiff_document->tiff, TIFFTAG_RESOLUTIONUNIT, &unit)) {
 			if (unit == RESUNIT_CENTIMETER) {
-				x *= 2.54;
-				y *= 2.54;
+				x *= 2.54f;
+				y *= 2.54f;
 			}
 		}
 	}
@@ -202,10 +202,9 @@ tiff_document_get_page_size (EvDocument *document,
 	TIFFGetField (tiff_document->tiff, TIFFTAG_IMAGEWIDTH, &w);
 	TIFFGetField (tiff_document->tiff, TIFFTAG_IMAGELENGTH, &h);
 	tiff_document_get_resolution (tiff_document, &x_res, &y_res);
-	h = h * (x_res / y_res);
 
-	*width = w;
-	*height = h;
+	*width = (gfloat)w;
+	*height = (gfloat)h * (x_res / y_res);
 
 	pop_handlers ();
 }
@@ -316,8 +315,8 @@ tiff_document_render (EvDocument      *document,
 	}
 
 	rotated_surface = ev_document_misc_surface_rotate_and_scale (surface,
-								     (width * rc->scale) + 0.5,
-								     (height * rc->scale * (x_res / y_res)) + 0.5,
+								     (gint)(width * rc->scale),
+								     (gint)(height * rc->scale * (x_res / y_res)),
 								     rc->rotation);
 	cairo_surface_destroy (surface);
 
@@ -391,8 +390,8 @@ tiff_document_render_pixbuf (EvDocument      *document,
 	pop_handlers ();
 
 	scaled_pixbuf = gdk_pixbuf_scale_simple (pixbuf,
-						 width * rc->scale,
-						 height * rc->scale * (x_res / y_res),
+						 (int)((gdouble)width * rc->scale),
+						 (int)((gdouble)height * rc->scale * (x_res / y_res)),
 						 GDK_INTERP_BILINEAR);
 	g_object_unref (pixbuf);
 

--- a/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
+++ b/cut-n-paste/toolbar-editor/egg-editable-toolbar.c
@@ -307,8 +307,8 @@ move_item_cb (GtkAction          *action,
                                    GDK_ACTION_MOVE,
                                    1,
                                    event,
-                                   event->motion.x,
-                                   event->motion.y);
+                                   (int)event->motion.x,
+                                   (int)event->motion.y);
   gdk_event_free (event);
   gtk_target_list_unref (list);
 }

--- a/cut-n-paste/zoom-control/ephy-zoom-action.c
+++ b/cut-n-paste/zoom-control/ephy-zoom-action.c
@@ -33,9 +33,9 @@
 
 struct _EphyZoomActionPrivate
 {
-	float zoom;
-	float min_zoom;
-	float max_zoom;
+	double zoom;
+	double min_zoom;
+	double max_zoom;
 };
 
 enum
@@ -60,8 +60,8 @@ G_GNUC_END_IGNORE_DEPRECATIONS;
 
 static void
 zoom_to_level_cb (EphyZoomControl *control,
-		  float zoom,
-		  EphyZoomAction *action)
+                  double           zoom,
+                  EphyZoomAction  *action)
 {
 	g_signal_emit (action, signals[ZOOM_TO_LEVEL_SIGNAL], 0, zoom);
 }
@@ -113,7 +113,7 @@ static void
 proxy_menu_activate_cb (GtkMenuItem *menu_item, EphyZoomAction *action)
 {
 	gint index;
-	float zoom;
+	double zoom;
 
 	/* menu item was toggled OFF */
 	if (!gtk_check_menu_item_get_active (GTK_CHECK_MENU_ITEM (menu_item))) return;
@@ -187,13 +187,13 @@ ephy_zoom_action_set_property (GObject *object,
 	switch (prop_id)
 	{
 		case PROP_ZOOM:
-			action->priv->zoom = g_value_get_float (value);
+			action->priv->zoom = g_value_get_double (value);
 			break;
 	        case PROP_MIN_ZOOM:
-			action->priv->min_zoom = g_value_get_float (value);
+			action->priv->min_zoom = g_value_get_double (value);
 			break;
 	        case PROP_MAX_ZOOM:
-			action->priv->max_zoom = g_value_get_float (value);
+			action->priv->max_zoom = g_value_get_double (value);
 			break;
 	}
 }
@@ -211,13 +211,13 @@ ephy_zoom_action_get_property (GObject *object,
 	switch (prop_id)
 	{
 		case PROP_ZOOM:
-			g_value_set_float (value, action->priv->zoom);
+			g_value_set_double (value, action->priv->zoom);
 			break;
 		case PROP_MIN_ZOOM:
-			g_value_set_float (value, action->priv->min_zoom);
+			g_value_set_double (value, action->priv->min_zoom);
 			break;
 		case PROP_MAX_ZOOM:
-			g_value_set_float (value, action->priv->max_zoom);
+			g_value_set_double (value, action->priv->max_zoom);
 			break;
 	}
 }
@@ -239,31 +239,31 @@ ephy_zoom_action_class_init (EphyZoomActionClass *class)
 
 	g_object_class_install_property (object_class,
 					 PROP_ZOOM,
-					 g_param_spec_float ("zoom",
-							     "Zoom",
-							     "Zoom",
-							     ZOOM_MINIMAL,
-							     ZOOM_MAXIMAL,
-							     1.0,
-							     G_PARAM_READWRITE));
+					 g_param_spec_double ("zoom",
+							      "Zoom",
+							      "Zoom",
+							      ZOOM_MINIMAL,
+							      ZOOM_MAXIMAL,
+							      1.0,
+							      G_PARAM_READWRITE));
 	g_object_class_install_property (object_class,
 					 PROP_MIN_ZOOM,
-					 g_param_spec_float ("min-zoom",
-							     "MinZoom",
-							     "The minimum zoom",
-							     ZOOM_MINIMAL,
-							     ZOOM_MAXIMAL,
-							     ZOOM_MINIMAL,
-							     G_PARAM_READWRITE));
+					 g_param_spec_double ("min-zoom",
+							      "MinZoom",
+							      "The minimum zoom",
+							      ZOOM_MINIMAL,
+							      ZOOM_MAXIMAL,
+							      ZOOM_MINIMAL,
+							      G_PARAM_READWRITE));
 	g_object_class_install_property (object_class,
 					 PROP_MAX_ZOOM,
-					 g_param_spec_float ("max-zoom",
-							     "MaxZoom",
-							     "The maximum zoom",
-							     ZOOM_MINIMAL,
-							     ZOOM_MAXIMAL,
-							     ZOOM_MAXIMAL,
-							     G_PARAM_READWRITE));
+					 g_param_spec_double ("max-zoom",
+							      "MaxZoom",
+							      "The maximum zoom",
+							      ZOOM_MINIMAL,
+							      ZOOM_MAXIMAL,
+							      ZOOM_MAXIMAL,
+							      G_PARAM_READWRITE));
 
 	signals[ZOOM_TO_LEVEL_SIGNAL] =
 		g_signal_new ("zoom_to_level",
@@ -271,10 +271,10 @@ ephy_zoom_action_class_init (EphyZoomActionClass *class)
 			      G_SIGNAL_RUN_FIRST,
 			      G_STRUCT_OFFSET (EphyZoomActionClass, zoom_to_level),
 			      NULL, NULL,
-			      g_cclosure_marshal_VOID__FLOAT,
+			      g_cclosure_marshal_VOID__DOUBLE,
 			      G_TYPE_NONE,
 			      1,
-			      G_TYPE_FLOAT);
+			      G_TYPE_DOUBLE);
 }
 
 static void
@@ -286,7 +286,7 @@ ephy_zoom_action_init (EphyZoomAction *action)
 }
 
 void
-ephy_zoom_action_set_zoom_level (EphyZoomAction *action, float zoom)
+ephy_zoom_action_set_zoom_level (EphyZoomAction *action, double zoom)
 {
 	g_return_if_fail (EPHY_IS_ZOOM_ACTION (action));
 
@@ -296,7 +296,7 @@ ephy_zoom_action_set_zoom_level (EphyZoomAction *action, float zoom)
 	g_object_notify (G_OBJECT (action), "zoom");
 }
 
-float
+double
 ephy_zoom_action_get_zoom_level (EphyZoomAction *action)
 {
 	g_return_val_if_fail (EPHY_IS_ZOOM_ACTION (action), 1.0);
@@ -306,7 +306,7 @@ ephy_zoom_action_get_zoom_level (EphyZoomAction *action)
 
 void
 ephy_zoom_action_set_min_zoom_level (EphyZoomAction *action,
-				     float           zoom)
+				     double          zoom)
 {
 	g_return_if_fail (EPHY_IS_ZOOM_ACTION (action));
 
@@ -321,7 +321,7 @@ ephy_zoom_action_set_min_zoom_level (EphyZoomAction *action,
 
 void
 ephy_zoom_action_set_max_zoom_level (EphyZoomAction *action,
-				     float           zoom)
+				     double          zoom)
 {
 	g_return_if_fail (EPHY_IS_ZOOM_ACTION (action));
 

--- a/cut-n-paste/zoom-control/ephy-zoom-action.h
+++ b/cut-n-paste/zoom-control/ephy-zoom-action.h
@@ -49,19 +49,19 @@ struct _EphyZoomActionClass
 {
 	GtkActionClass parent_class;
 
-	void (* zoom_to_level)	(EphyZoomAction *action, float level);
+	void (* zoom_to_level)	(EphyZoomAction *action, double level);
 };
 
 GType	ephy_zoom_action_get_type	    (void) G_GNUC_CONST;
 
 void	ephy_zoom_action_set_zoom_level	    (EphyZoomAction *action,
-					     float           zoom);
-float	ephy_zoom_action_get_zoom_level	    (EphyZoomAction *action);
+					     double          zoom);
+double	ephy_zoom_action_get_zoom_level	    (EphyZoomAction *action);
 
 void    ephy_zoom_action_set_min_zoom_level (EphyZoomAction *action,
-					     float           zoom);
+					     double          zoom);
 void    ephy_zoom_action_set_max_zoom_level (EphyZoomAction *action,
-					     float           zoom);
+					     double          zoom);
 
 G_END_DECLS
 

--- a/cut-n-paste/zoom-control/ephy-zoom-control.c
+++ b/cut-n-paste/zoom-control/ephy-zoom-control.c
@@ -31,9 +31,9 @@
 struct _EphyZoomControlPrivate
 {
 	GtkComboBox *combo;
-	float zoom;
-	float min_zoom;
-	float max_zoom;
+	double zoom;
+	double min_zoom;
+	double max_zoom;
 	guint handler_id;
 };
 
@@ -65,7 +65,7 @@ static void
 combo_changed_cb (GtkComboBox *combo, EphyZoomControl *control)
 {
 	gint index;
-	float zoom;
+	double zoom;
 
 	index = gtk_combo_box_get_active (combo);
 	zoom = zoom_levels[index].level;
@@ -230,13 +230,13 @@ ephy_zoom_control_set_property (GObject *object,
 	switch (prop_id)
 	{
 		case PROP_ZOOM:
-			p->zoom = g_value_get_float (value);
+			p->zoom = g_value_get_double (value);
 			break;
 		case PROP_MIN_ZOOM:
-			p->min_zoom = g_value_get_float (value);
+			p->min_zoom = g_value_get_double (value);
 			break;
 		case PROP_MAX_ZOOM:
-			p->max_zoom = g_value_get_float (value);
+			p->max_zoom = g_value_get_double (value);
 			break;
 	}
 }
@@ -256,13 +256,13 @@ ephy_zoom_control_get_property (GObject *object,
 	switch (prop_id)
 	{
 		case PROP_ZOOM:
-			g_value_set_float (value, p->zoom);
+			g_value_set_double (value, p->zoom);
 			break;
 		case PROP_MIN_ZOOM:
-			g_value_set_float (value, p->min_zoom);
+			g_value_set_double (value, p->min_zoom);
 			break;
 		case PROP_MAX_ZOOM:
-			g_value_set_float (value, p->max_zoom);
+			g_value_set_double (value, p->max_zoom);
 			break;
 	}
 }
@@ -280,31 +280,31 @@ ephy_zoom_control_class_init (EphyZoomControlClass *klass)
 
 	g_object_class_install_property (object_class,
 					 PROP_ZOOM,
-					 g_param_spec_float ("zoom",
-							     "Zoom",
-							     "Zoom level to display in the item.",
-							     ZOOM_MINIMAL,
-							     ZOOM_MAXIMAL,
-							     1.0,
-							     G_PARAM_READWRITE));
+					 g_param_spec_double ("zoom",
+							      "Zoom",
+							      "Zoom level to display in the item.",
+							      ZOOM_MINIMAL,
+							      ZOOM_MAXIMAL,
+							      1.0,
+							      G_PARAM_READWRITE));
 	g_object_class_install_property (object_class,
 					 PROP_MIN_ZOOM,
-					 g_param_spec_float ("min-zoom",
-							     "MinZoom",
-							     "The minimum zoom",
-							     ZOOM_MINIMAL,
-							     ZOOM_MAXIMAL,
-							     ZOOM_MINIMAL,
-							     G_PARAM_READWRITE));
+					 g_param_spec_double ("min-zoom",
+							      "MinZoom",
+							      "The minimum zoom",
+							      ZOOM_MINIMAL,
+							      ZOOM_MAXIMAL,
+							      ZOOM_MINIMAL,
+							      G_PARAM_READWRITE));
 	g_object_class_install_property (object_class,
 					 PROP_MAX_ZOOM,
-					 g_param_spec_float ("max-zoom",
-							     "MaxZoom",
-							     "The maximum zoom",
-							     ZOOM_MINIMAL,
-							     ZOOM_MAXIMAL,
-							     ZOOM_MAXIMAL,
-							     G_PARAM_READWRITE));
+					 g_param_spec_double ("max-zoom",
+							      "MaxZoom",
+							      "The maximum zoom",
+							      ZOOM_MINIMAL,
+							      ZOOM_MAXIMAL,
+							      ZOOM_MAXIMAL,
+							      G_PARAM_READWRITE));
 
 	signals[ZOOM_TO_LEVEL_SIGNAL] =
 		g_signal_new ("zoom_to_level",
@@ -313,14 +313,14 @@ ephy_zoom_control_class_init (EphyZoomControlClass *klass)
 			      G_STRUCT_OFFSET (EphyZoomControlClass,
 					       zoom_to_level),
 			      NULL, NULL,
-			      g_cclosure_marshal_VOID__FLOAT,
+			      g_cclosure_marshal_VOID__DOUBLE,
 			      G_TYPE_NONE,
 			      1,
-			      G_TYPE_FLOAT);
+			      G_TYPE_DOUBLE);
 }
 
 void
-ephy_zoom_control_set_zoom_level (EphyZoomControl *control, float zoom)
+ephy_zoom_control_set_zoom_level (EphyZoomControl *control, double zoom)
 {
 	g_return_if_fail (EPHY_IS_ZOOM_CONTROL (control));
 
@@ -330,7 +330,7 @@ ephy_zoom_control_set_zoom_level (EphyZoomControl *control, float zoom)
 	g_object_notify (G_OBJECT (control), "zoom");
 }
 
-float
+double
 ephy_zoom_control_get_zoom_level (EphyZoomControl *control)
 {
 	g_return_val_if_fail (EPHY_IS_ZOOM_CONTROL (control), 1.0);

--- a/cut-n-paste/zoom-control/ephy-zoom-control.h
+++ b/cut-n-paste/zoom-control/ephy-zoom-control.h
@@ -41,7 +41,7 @@ struct _EphyZoomControlClass
 	GtkToolItemClass parent_class;
 
 	/* signals */
-	void (*zoom_to_level) 	(EphyZoomControl *control, float level);
+	void (*zoom_to_level) 	(EphyZoomControl *control, double level);
 };
 
 struct _EphyZoomControl
@@ -54,9 +54,9 @@ struct _EphyZoomControl
 
 GType	ephy_zoom_control_get_type	 (void);
 
-void	ephy_zoom_control_set_zoom_level (EphyZoomControl *control, float zoom);
+void	ephy_zoom_control_set_zoom_level (EphyZoomControl *control, double zoom);
 
-float	ephy_zoom_control_get_zoom_level (EphyZoomControl *control);
+double	ephy_zoom_control_get_zoom_level (EphyZoomControl *control);
 
 G_END_DECLS
 

--- a/cut-n-paste/zoom-control/ephy-zoom.c
+++ b/cut-n-paste/zoom-control/ephy-zoom.c
@@ -25,10 +25,10 @@
 #include <math.h>
 
 guint
-ephy_zoom_get_zoom_level_index (float level)
+ephy_zoom_get_zoom_level_index (double level)
 {
 	guint i;
-	float previous, current, mean;
+	double previous, current, mean;
 
 	/* Handle our options at the beginning of the list. */
 	if (level == EPHY_ZOOM_FIT_PAGE) {
@@ -55,8 +55,8 @@ ephy_zoom_get_zoom_level_index (float level)
 }
 
 
-float
-ephy_zoom_get_changed_zoom_level (float level, gint steps)
+static double
+ephy_zoom_get_changed_zoom_level (double level, gint steps)
 {
 	guint index;
 
@@ -64,7 +64,8 @@ ephy_zoom_get_changed_zoom_level (float level, gint steps)
 	return zoom_levels[CLAMP(index + steps, 3, n_zoom_levels - 1)].level;
 }
 
-float	ephy_zoom_get_nearest_zoom_level (float level)
+double
+ephy_zoom_get_nearest_zoom_level (double level)
 {
 	return ephy_zoom_get_changed_zoom_level (level, 0);
 }

--- a/cut-n-paste/zoom-control/ephy-zoom.h
+++ b/cut-n-paste/zoom-control/ephy-zoom.h
@@ -41,7 +41,7 @@ static const
 struct
 {
 	gchar *name;
-	float level;
+	double level;
 }
 
 zoom_levels[] =
@@ -72,11 +72,9 @@ static const guint n_zoom_levels = G_N_ELEMENTS (zoom_levels);
 #define ZOOM_IN		(-1.0)
 #define ZOOM_OUT	(-2.0)
 
-guint	ephy_zoom_get_zoom_level_index	 (float level);
+guint	ephy_zoom_get_zoom_level_index	 (double level);
 
-float	ephy_zoom_get_changed_zoom_level (float level, gint steps);
-
-float	ephy_zoom_get_nearest_zoom_level (float level);
+double	ephy_zoom_get_nearest_zoom_level (double level);
 
 G_END_DECLS
 

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -536,9 +536,9 @@ ev_annotation_get_color (EvAnnotation *annot,
     ev_annotation_get_rgba (annot, &rgba);
 
     color->pixel = 0;
-    color->red = CLAMP (rgba.red * 65535. + 0.5, 0, 65535);
-    color->green = CLAMP (rgba.green * 65535. + 0.5, 0, 65535);
-    color->blue = CLAMP (rgba.blue * 65535. + 0.5, 0, 65535);
+    color->red   = (guint16)(rgba.red   * 65535.0);
+    color->green = (guint16)(rgba.green * 65535.0);
+    color->blue  = (guint16)(rgba.blue  * 65535.0);
 }
 
 /**

--- a/libview/ev-annotation-window.c
+++ b/libview/ev-annotation-window.c
@@ -231,8 +231,10 @@ ev_annotation_window_resize (EvAnnotationWindow *window,
 					      window->resize_sw == ebox ?
 					      GDK_WINDOW_EDGE_SOUTH_WEST :
 					      GDK_WINDOW_EDGE_SOUTH_EAST,
-					      event->button, event->x_root,
-					      event->y_root, event->time);
+					      event->button,
+		                              (int)event->x_root,
+					      (int)event->y_root,
+		                              event->time);
 		return TRUE;
 	}
 
@@ -288,12 +290,12 @@ ev_annotation_window_button_press_event (GtkWidget      *widget,
 
 	if (event->type == GDK_BUTTON_PRESS && event->button == 1) {
 		window->in_move = TRUE;
-		window->x = event->x_root - event->x;
-		window->y = event->y_root - event->y;
+		window->x = (int)(event->x_root - event->x);
+		window->y = (int)(event->y_root - event->y);
 		gtk_window_begin_move_drag (GTK_WINDOW (widget),
 					    event->button,
-					    event->x_root,
-					    event->y_root,
+					    (int)event->x_root,
+					    (int)event->y_root,
 					    event->time);
 		return TRUE;
 	}

--- a/libview/ev-form-field-accessible.c
+++ b/libview/ev-form-field-accessible.c
@@ -53,10 +53,10 @@ ev_form_field_accessible_get_extents (AtkComponent *atk_component,
 	view_accessible = ev_page_accessible_get_view_accessible (self->priv->page);
 	page = ev_page_accessible_get_page (self->priv->page);
 	_transform_doc_rect_to_atk_rect (view_accessible, page, &self->priv->area, &atk_rect, coord_type);
-	*x = atk_rect.x1;
-	*y = atk_rect.y1;
-	*width = atk_rect.x2 - atk_rect.x1;
-	*height = atk_rect.y2 - atk_rect.y1;
+	*x = (int)atk_rect.x1;
+	*y = (int)atk_rect.y1;
+	*width = (int)(atk_rect.x2 - atk_rect.x1);
+	*height = (int)(atk_rect.y2 - atk_rect.y1);
 }
 
 static gboolean

--- a/libview/ev-image-accessible.c
+++ b/libview/ev-image-accessible.c
@@ -64,10 +64,10 @@ ev_image_accessible_get_extents (AtkComponent *atk_component,
 	EvRectangle atk_rect;
 
 	ev_image_accessible_get_atk_rect (ATK_OBJECT (atk_component), coord_type, &atk_rect);
-	*x = atk_rect.x1;
-	*y = atk_rect.y1;
-	*width = atk_rect.x2 - atk_rect.x1;
-	*height = atk_rect.y2 - atk_rect.y1;
+	*x = (int)atk_rect.x1;
+	*y = (int)atk_rect.y1;
+	*width = (int)(atk_rect.x2 - atk_rect.x1);
+	*height = (int)(atk_rect.y2 - atk_rect.y1);
 }
 
 static void
@@ -98,8 +98,8 @@ ev_image_accessible_get_image_size (AtkImage *atk_image,
 	EvRectangle atk_rect;
 
 	ev_image_accessible_get_atk_rect (ATK_OBJECT (atk_image), ATK_XY_WINDOW, &atk_rect);
-	*width = atk_rect.x2 - atk_rect.x1;
-	*height = atk_rect.y2 - atk_rect.y1;
+	*width = (int)(atk_rect.x2 - atk_rect.x1);
+	*height = (int)(atk_rect.y2 - atk_rect.y1);
 }
 
 static void
@@ -111,8 +111,8 @@ ev_image_accessible_get_image_position (AtkImage     *atk_image,
 	EvRectangle atk_rect;
 
 	ev_image_accessible_get_atk_rect (ATK_OBJECT (atk_image), ATK_XY_WINDOW, &atk_rect);
-	*x = atk_rect.x1;
-	*y = atk_rect.y1;
+	*x = (int)atk_rect.x1;
+	*y = (int)atk_rect.y1;
 }
 
 static AtkStateSet *

--- a/libview/ev-link-accessible.c
+++ b/libview/ev-link-accessible.c
@@ -389,10 +389,10 @@ ev_link_accessible_get_extents (AtkComponent *atk_component,
 	view_accessible = ev_page_accessible_get_view_accessible (self->priv->page);
 	page = ev_page_accessible_get_page (self->priv->page);
 	_transform_doc_rect_to_atk_rect (view_accessible, page, &self->priv->area, &atk_rect, coord_type);
-	*x = atk_rect.x1;
-	*y = atk_rect.y1;
-	*width = atk_rect.x2 - atk_rect.x1;
-	*height = atk_rect.y2 - atk_rect.y1;
+	*x = (int)atk_rect.x1;
+	*y = (int)atk_rect.y1;
+	*width = (int)(atk_rect.x2 - atk_rect.x1);
+	*height = (int)(atk_rect.y2 - atk_rect.y1);
 }
 
 static gboolean

--- a/libview/ev-page-accessible.c
+++ b/libview/ev-page-accessible.c
@@ -92,7 +92,7 @@ compare_mappings (EvMapping *a, EvMapping *b)
 	dy = a->area.y1 - b->area.y1;
 	dx = a->area.x1 - b->area.x1;
 
-	return ABS (dy) > 10 ? dy : dx;
+	return ABS (dy) > 10 ? (int)dy : (int)dx;
 }
 
 static void
@@ -1197,10 +1197,10 @@ ev_page_accessible_get_extents (AtkComponent *atk_component,
 	doc_rect.y2 = page_area.y + page_area.height;
 	_transform_doc_rect_to_atk_rect (self->priv->view_accessible, self->priv->page, &doc_rect, &atk_rect, coord_type);
 
-	*x = atk_rect.x1;
-	*y = atk_rect.y1;
-	*width = atk_rect.x2 - atk_rect.x1;
-	*height = atk_rect.y2 - atk_rect.y1;
+	*x = (int)atk_rect.x1;
+	*y = (int)atk_rect.y1;
+	*width = (int)(atk_rect.x2 - atk_rect.x1);
+	*height = (int)(atk_rect.y2 - atk_rect.y1);
 }
 
 static void

--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -90,7 +90,7 @@ static CacheJobInfo *find_job_cache             (EvPixbufCache      *pixbuf_cach
 static gboolean      new_selection_surface_needed(EvPixbufCache      *pixbuf_cache,
 						  CacheJobInfo       *job_info,
 						  gint                page,
-						  gfloat              scale);
+						  gdouble             scale);
 
 
 /* These are used for iterating through the prev and next arrays */
@@ -337,7 +337,7 @@ job_finished_cb (EvJob         *job,
 static void
 check_job_size_and_unref (EvPixbufCache *pixbuf_cache,
 			  CacheJobInfo  *job_info,
-			  gfloat         scale)
+			  gdouble        scale)
 {
 	gint width, height;
 	gint device_scale;
@@ -619,7 +619,7 @@ find_job_cache (EvPixbufCache *pixbuf_cache,
 
 static void
 ev_pixbuf_cache_clear_job_sizes (EvPixbufCache *pixbuf_cache,
-				 gfloat         scale)
+				 gdouble        scale)
 {
 	int i;
 
@@ -659,7 +659,7 @@ add_job (EvPixbufCache  *pixbuf_cache,
 	 gint            height,
 	 gint            page,
 	 gint            rotation,
-	 gfloat          scale,
+	 gdouble         scale,
 	 EvJobPriority   priority)
 {
 	job_info->device_scale = get_device_scale (pixbuf_cache);
@@ -699,7 +699,7 @@ add_job_if_needed (EvPixbufCache *pixbuf_cache,
 		   CacheJobInfo  *job_info,
 		   gint           page,
 		   gint           rotation,
-		   gfloat         scale,
+		   gdouble        scale,
 		   EvJobPriority  priority)
 {
 	gint device_scale = get_device_scale (pixbuf_cache);
@@ -739,7 +739,7 @@ add_job_if_needed (EvPixbufCache *pixbuf_cache,
 static void
 add_prev_jobs_if_needed (EvPixbufCache *pixbuf_cache,
                          gint           rotation,
-                         gfloat         scale)
+                         gdouble        scale)
 {
         CacheJobInfo *job_info;
         int page;
@@ -758,7 +758,7 @@ add_prev_jobs_if_needed (EvPixbufCache *pixbuf_cache,
 static void
 add_next_jobs_if_needed (EvPixbufCache *pixbuf_cache,
                          gint           rotation,
-                         gfloat         scale)
+                         gdouble        scale)
 {
         CacheJobInfo *job_info;
         int page;
@@ -777,7 +777,7 @@ add_next_jobs_if_needed (EvPixbufCache *pixbuf_cache,
 static void
 ev_pixbuf_cache_add_jobs_if_needed (EvPixbufCache *pixbuf_cache,
 				    gint           rotation,
-				    gfloat         scale)
+				    gdouble        scale)
 {
 	CacheJobInfo *job_info;
 	int page;
@@ -913,7 +913,7 @@ static gboolean
 new_selection_surface_needed (EvPixbufCache *pixbuf_cache,
 			      CacheJobInfo  *job_info,
 			      gint           page,
-			      gfloat         scale)
+			      gdouble        scale)
 {
 	if (job_info->selection)
 		return job_info->selection_scale != scale;
@@ -924,7 +924,7 @@ static gboolean
 new_selection_region_needed (EvPixbufCache *pixbuf_cache,
                              CacheJobInfo  *job_info,
                              gint           page,
-                             gfloat         scale)
+                             gdouble        scale)
 {
 	if (job_info->selection_region)
 		return job_info->selection_region_scale != scale;
@@ -935,7 +935,7 @@ static void
 clear_selection_surface_if_needed (EvPixbufCache *pixbuf_cache,
                                    CacheJobInfo  *job_info,
                                    gint           page,
-                                   gfloat         scale)
+                                   gdouble        scale)
 {
 	if (new_selection_surface_needed (pixbuf_cache, job_info, page, scale)) {
 		if (job_info->selection)
@@ -949,7 +949,7 @@ static void
 clear_selection_region_if_needed (EvPixbufCache *pixbuf_cache,
                                   CacheJobInfo  *job_info,
                                   gint           page,
-                                  gfloat         scale)
+                                  gdouble        scale)
 {
 	if (new_selection_region_needed (pixbuf_cache, job_info, page, scale)) {
 		if (job_info->selection_region)
@@ -1022,7 +1022,7 @@ ev_pixbuf_cache_style_changed (EvPixbufCache *pixbuf_cache)
 cairo_surface_t *
 ev_pixbuf_cache_get_selection_surface (EvPixbufCache   *pixbuf_cache,
                                        gint             page,
-                                       gfloat           scale)
+                                       gdouble          scale)
 {
 	CacheJobInfo *job_info;
 
@@ -1092,7 +1092,7 @@ ev_pixbuf_cache_get_selection_surface (EvPixbufCache   *pixbuf_cache,
 cairo_region_t *
 ev_pixbuf_cache_get_selection_region (EvPixbufCache *pixbuf_cache,
                                       gint           page,
-                                      gfloat         scale)
+                                      gdouble        scale)
 {
 	CacheJobInfo *job_info;
 

--- a/libview/ev-pixbuf-cache.h
+++ b/libview/ev-pixbuf-cache.h
@@ -78,10 +78,10 @@ void           ev_pixbuf_cache_set_inverted_colors  (EvPixbufCache *pixbuf_cache
 /* Selection */
 cairo_surface_t *ev_pixbuf_cache_get_selection_surface (EvPixbufCache   *pixbuf_cache,
 							gint             page,
-							gfloat           scale);
+							gdouble          scale);
 cairo_region_t *ev_pixbuf_cache_get_selection_region (EvPixbufCache *pixbuf_cache,
 						      gint           page,
-						      gfloat         scale);
+						      gdouble        scale);
 void           ev_pixbuf_cache_set_selection_list   (EvPixbufCache *pixbuf_cache,
 						     GList         *selection_list);
 GList         *ev_pixbuf_cache_get_selection_list   (EvPixbufCache *pixbuf_cache);

--- a/libview/ev-view-accessible.c
+++ b/libview/ev-view-accessible.c
@@ -545,7 +545,7 @@ ev_view_accessible_is_doc_rect_showing (EvViewAccessible *accessible,
 	EvView *view;
 	GdkRectangle view_rect;
 	GtkAllocation allocation;
-	gint x, y;
+	gdouble x, y;
 	gboolean hidden;
 
 	view = EV_VIEW (gtk_accessible_get_widget (GTK_ACCESSIBLE (accessible)));

--- a/libview/ev-view-presentation.c
+++ b/libview/ev-view-presentation.c
@@ -252,7 +252,7 @@ ev_view_presentation_transition_start (EvViewPresentation *pview)
 							     pview->current_page);
 	if (duration >= 0) {
 		        pview->trans_timeout_id =
-				g_timeout_add_seconds (duration,
+				g_timeout_add_seconds ((int)(duration + 0.5),
 						       (GSourceFunc) transition_next_page,
 						       pview);
 	}

--- a/shell/ev-sidebar-attachments.c
+++ b/shell/ev-sidebar-attachments.c
@@ -286,8 +286,8 @@ ev_sidebar_attachments_button_press (EvSidebarAttachments *ev_attachbar,
 				EvAttachment *attachment;
 
 				attachment = ev_sidebar_attachments_get_attachment_at_pos (ev_attachbar,
-											   event->x,
-											   event->y);
+											   (int)(event->x + 0.5),
+											   (int)(event->y + 0.5));
 				if (!attachment)
 					return FALSE;
 
@@ -307,7 +307,9 @@ ev_sidebar_attachments_button_press (EvSidebarAttachments *ev_attachbar,
 			}
 			break;
 	        case 3:
-			return ev_sidebar_attachments_popup_menu_show (ev_attachbar, event->x, event->y);
+			return ev_sidebar_attachments_popup_menu_show (ev_attachbar,
+			                                               (int)(event->x + 0.5),
+			                                               (int)(event->y + 0.5));
 	}
 
 	return FALSE;

--- a/shell/ev-sidebar-bookmarks.c
+++ b/shell/ev-sidebar-bookmarks.c
@@ -367,7 +367,10 @@ ev_sidebar_bookmarks_button_press (GtkWidget          *widget,
         if (event->button != 3)
                 return FALSE;
 
-        return ev_sidebar_bookmarks_popup_menu_show (sidebar_bookmarks, event->x, event->y, FALSE);
+        return ev_sidebar_bookmarks_popup_menu_show (sidebar_bookmarks,
+	                                             (int)event->x,
+	                                             (int)event->y,
+	                                             FALSE);
 }
 
 static gboolean

--- a/shell/ev-sidebar-links.c
+++ b/shell/ev-sidebar-links.c
@@ -355,8 +355,8 @@ button_press_cb (GtkWidget *treeview,
 
 	if (event->button == 3) {
 	        if (gtk_tree_view_get_path_at_pos (GTK_TREE_VIEW (treeview),
-        	                                   event->x,
-                	                           event->y,
+        	                                   (int)event->x,
+                	                           (int)event->y,
 	                                           &path,
         	                                   NULL, NULL, NULL)) {
 			gtk_tree_view_set_cursor (GTK_TREE_VIEW (treeview),

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -381,7 +381,7 @@ static void 	ev_window_emit_doc_loaded		(EvWindow	  *window);
 static void     ev_window_setup_bookmarks               (EvWindow         *window);
 
 static void    zoom_control_changed_cb                 (EphyZoomAction *action,
-                                                         float           zoom,
+                                                         double           zoom,
                                                          EvWindow       *ev_window);
 
 static gchar *caja_sendto = NULL;
@@ -632,8 +632,8 @@ ev_window_update_actions (EvWindow *ev_window)
 	sizing_mode = ev_document_model_get_sizing_mode (ev_window->priv->model);
 	if (has_pages && sizing_mode != EV_SIZING_FIT_WIDTH && sizing_mode != EV_SIZING_FIT_PAGE) {
 		GtkAction *action;
-		float      zoom;
-		float      real_zoom;
+		double     zoom;
+		double     real_zoom;
 
 		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		action = gtk_action_group_get_action (ev_window->priv->action_group,
@@ -5940,7 +5940,7 @@ find_bar_visibility_changed_cb (EggFindBar *find_bar,
 
 static void
 zoom_control_changed_cb (EphyZoomAction *action,
-			 float           zoom,
+			 double           zoom,
 			 EvWindow       *ev_window)
 {
 	EvSizingMode mode;


### PR DESCRIPTION
```C
ephy-zoom.h:54:15: warning: conversion from 'double' to 'float' changes value from '7.0710678110000003e-1' to '7.07106769e-1f' [-Wfloat-conversion]
   54 |  { N_("70%"), 0.7071067811 },
      |               ^~~~~~~~~~~~
ephy-zoom.h:55:15: warning: conversion from 'double' to 'float' changes value from '8.4089641520000002e-1' to '8.40896428e-1f' [-Wfloat-conversion]
   55 |  { N_("85%"), 0.8408964152 },
      |               ^~~~~~~~~~~~
ephy-zoom.h:57:16: warning: conversion from 'double' to 'float' changes value from '1.1892071149000001e+0' to '1.18920708e+0f' [-Wfloat-conversion]
   57 |  { N_("125%"), 1.1892071149 },
      |                ^~~~~~~~~~~~
ephy-zoom.h:58:16: warning: conversion from 'double' to 'float' changes value from '1.4142135623000001e+0' to '1.41421354e+0f' [-Wfloat-conversion]
   58 |  { N_("150%"), 1.4142135623 },
      |                ^~~~~~~~~~~~
ephy-zoom.h:59:16: warning: conversion from 'double' to 'float' changes value from '1.6817928304e+0' to '1.68179286e+0f' [-Wfloat-conversion]
   59 |  { N_("175%"), 1.6817928304 },
      |                ^~~~~~~~~~~~
ephy-zoom.h:61:16: warning: conversion from 'double' to 'float' changes value from '2.8284271247000001e+0' to '2.82842708e+0f' [-Wfloat-conversion]
   61 |  { N_("300%"), 2.8284271247 },
      |                ^~~~~~~~~~~~
--
ephy-zoom.c:47:10: warning: conversion from 'double' to 'float' may change value [-Wfloat-conversion]
   47 |   mean = sqrt (previous * current);
      |          ^~~~
--
ephy-zoom.h:54:15: warning: conversion from 'double' to 'float' changes value from '7.0710678110000003e-1' to '7.07106769e-1f' [-Wfloat-conversion]
   54 |  { N_("70%"), 0.7071067811 },
      |               ^~~~~~~~~~~~
ephy-zoom.h:55:15: warning: conversion from 'double' to 'float' changes value from '8.4089641520000002e-1' to '8.40896428e-1f' [-Wfloat-conversion]
   55 |  { N_("85%"), 0.8408964152 },
      |               ^~~~~~~~~~~~
ephy-zoom.h:57:16: warning: conversion from 'double' to 'float' changes value from '1.1892071149000001e+0' to '1.18920708e+0f' [-Wfloat-conversion]
   57 |  { N_("125%"), 1.1892071149 },
      |                ^~~~~~~~~~~~
ephy-zoom.h:58:16: warning: conversion from 'double' to 'float' changes value from '1.4142135623000001e+0' to '1.41421354e+0f' [-Wfloat-conversion]
   58 |  { N_("150%"), 1.4142135623 },
      |                ^~~~~~~~~~~~
ephy-zoom.h:59:16: warning: conversion from 'double' to 'float' changes value from '1.6817928304e+0' to '1.68179286e+0f' [-Wfloat-conversion]
   59 |  { N_("175%"), 1.6817928304 },
      |                ^~~~~~~~~~~~
ephy-zoom.h:61:16: warning: conversion from 'double' to 'float' changes value from '2.8284271247000001e+0' to '2.82842708e+0f' [-Wfloat-conversion]
   61 |  { N_("300%"), 2.8284271247 },
      |                ^~~~~~~~~~~~
--
ephy-zoom.h:54:15: warning: conversion from 'double' to 'float' changes value from '7.0710678110000003e-1' to '7.07106769e-1f' [-Wfloat-conversion]
   54 |  { N_("70%"), 0.7071067811 },
      |               ^~~~~~~~~~~~
ephy-zoom.h:55:15: warning: conversion from 'double' to 'float' changes value from '8.4089641520000002e-1' to '8.40896428e-1f' [-Wfloat-conversion]
   55 |  { N_("85%"), 0.8408964152 },
      |               ^~~~~~~~~~~~
ephy-zoom.h:57:16: warning: conversion from 'double' to 'float' changes value from '1.1892071149000001e+0' to '1.18920708e+0f' [-Wfloat-conversion]
   57 |  { N_("125%"), 1.1892071149 },
      |                ^~~~~~~~~~~~
ephy-zoom.h:58:16: warning: conversion from 'double' to 'float' changes value from '1.4142135623000001e+0' to '1.41421354e+0f' [-Wfloat-conversion]
   58 |  { N_("150%"), 1.4142135623 },
      |                ^~~~~~~~~~~~
ephy-zoom.h:59:16: warning: conversion from 'double' to 'float' changes value from '1.6817928304e+0' to '1.68179286e+0f' [-Wfloat-conversion]
   59 |  { N_("175%"), 1.6817928304 },
      |                ^~~~~~~~~~~~
ephy-zoom.h:61:16: warning: conversion from 'double' to 'float' changes value from '2.8284271247000001e+0' to '2.82842708e+0f' [-Wfloat-conversion]
   61 |  { N_("300%"), 2.8284271247 },
      |                ^~~~~~~~~~~~
--
egg-editable-toolbar.c:310:49: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  310 |                                    event->motion.x,
      |                                    ~~~~~~~~~~~~~^~
egg-editable-toolbar.c:311:49: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  311 |                                    event->motion.y);
      |                                    ~~~~~~~~~~~~~^~
--
/usr/include/glib-2.0/glib/gmacros.h:811:30: warning: conversion from 'double' to 'guint16' {aka 'short unsigned int'} may change value [-Wfloat-conversion]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                              ^
--
/usr/include/glib-2.0/glib/gmacros.h:811:30: warning: conversion from 'double' to 'guint16' {aka 'short unsigned int'} may change value [-Wfloat-conversion]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                              ^
--
/usr/include/glib-2.0/glib/gmacros.h:811:30: warning: conversion from 'double' to 'guint16' {aka 'short unsigned int'} may change value [-Wfloat-conversion]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                              ^
--
djvu-document.c:359:12: warning: conversion from 'double' to 'int' may change value [-Wfloat-conversion]
  359 |            page_width, page_height);
      |            ^~~~~~~~~~
djvu-document.c:359:24: warning: conversion from 'double' to 'int' may change value [-Wfloat-conversion]
  359 |            page_width, page_height);
      |                        ^~~~~~~~~~~
djvu-document.c:365:12: warning: conversion from 'double' to 'unsigned int' may change value [-Wfloat-conversion]
  365 |  prect.w = page_width;
      |            ^~~~~~~~~~
djvu-document.c:366:12: warning: conversion from 'double' to 'unsigned int' may change value [-Wfloat-conversion]
  366 |  prect.h = page_height;
      |            ^~~~~~~~~~~
--
tiff-document.c:173:10: warning: conversion from 'double' to 'gfloat' {aka 'float'} may change value [-Wfloat-conversion]
  173 |     x *= 2.54;
      |          ^~~~
tiff-document.c:174:10: warning: conversion from 'double' to 'gfloat' {aka 'float'} may change value [-Wfloat-conversion]
  174 |     y *= 2.54;
      |          ^~~~
--
tiff-document.c:205:6: warning: conversion from 'gfloat' {aka 'float'} to 'guint32' {aka 'unsigned int'} may change value [-Wfloat-conversion]
  205 |  h = h * (x_res / y_res);
      |      ^
--
tiff-document.c:319:34: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  319 |              (width * rc->scale) + 0.5,
      |              ~~~~~~~~~~~~~~~~~~~~^~~~~
tiff-document.c:320:53: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  320 |              (height * rc->scale * (x_res / y_res)) + 0.5,
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
--
tiff-document.c:394:14: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  394 |        width * rc->scale,
      |        ~~~~~~^~~~~~~~~~~
tiff-document.c:395:27: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  395 |        height * rc->scale * (x_res / y_res),
      |        ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
--
cairo-device.c:219:15: warning: conversion from 'double' to 'guint16' {aka 'short unsigned int'} may change value [-Wfloat-conversion]
  219 |   color.red = frac * color_fg.red;
      |               ^~~~
cairo-device.c:220:17: warning: conversion from 'double' to 'guint16' {aka 'short unsigned int'} may change value [-Wfloat-conversion]
  220 |   color.green = frac * color_fg.green;
      |                 ^~~~
cairo-device.c:221:16: warning: conversion from 'double' to 'guint16' {aka 'short unsigned int'} may change value [-Wfloat-conversion]
  221 |   color.blue = frac * color_fg.blue;
      |                ^~~~
cairo-device.c:222:11: warning: conversion from 'double' to 'unsigned int' may change value [-Wfloat-conversion]
  222 |   alpha = frac * 0xFF;
      |           ^~~~
--
cairo-device.c:335:15: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  335 |  page_width = dvi->dvi_page_w * dvi->params.conv + 2 * cairo_device->xmargin;
      |               ^~~
cairo-device.c:336:16: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  336 |  page_height = dvi->dvi_page_h * dvi->params.vconv + 2 * cairo_device->ymargin;
      |                ^~~
--
dvi-document.c:180:19: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  180 |  required_width = dvi_document->base_width * rc->scale + 0.5;
      |                   ^~~~~~~~~~~~
dvi-document.c:181:20: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  181 |  required_height = dvi_document->base_height * rc->scale + 0.5;
      |                    ^~~~~~~~~~~~
dvi-document.c:182:19: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  182 |  proposed_width = dvi_document->context->dvi_page_w * dvi_document->context->params.conv;
      |                   ^~~~~~~~~~~~
dvi-document.c:183:20: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  183 |  proposed_height = dvi_document->context->dvi_page_h * dvi_document->context->params.vconv;
      |                    ^~~~~~~~~~~~
--
dvi-document.c:301:19: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  301 |  proposed_width = dvi_document->context->dvi_page_w * dvi_document->context->params.conv;
      |                   ^~~~~~~~~~~~
dvi-document.c:302:20: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  302 |  proposed_height = dvi_document->context->dvi_page_h * dvi_document->context->params.vconv;
      |                    ^~~~~~~~~~~~
--
dvi-document.c:433:13: warning: conversion from 'double' to 'int' may change value [-Wfloat-conversion]
  433 |         i = floor (h);
      |             ^~~~~
--
dvi-document.c:510:31: warning: conversion from 'gdouble' {aka 'double'} to 'guchar' {aka 'unsigned char'} may change value [-Wfloat-conversion]
  510 |                         red = 255 * rgb[0];
      |                               ^~~
dvi-document.c:511:33: warning: conversion from 'gdouble' {aka 'double'} to 'guchar' {aka 'unsigned char'} may change value [-Wfloat-conversion]
  511 |                         green = 255 * rgb[1];
      |                                 ^~~
dvi-document.c:512:32: warning: conversion from 'gdouble' {aka 'double'} to 'guchar' {aka 'unsigned char'} may change value [-Wfloat-conversion]
  512 |                         blue = 255 * rgb[2];
      |                                ^~~
--
dvi-document.c:521:41: warning: conversion from 'gdouble' {aka 'double'} to 'float' may change value [-Wfloat-conversion]
  521 |                         if (hsb2rgb (hsb[0], hsb[1], hsb[2], &red, &green, &blue))
      |                                      ~~~^~~
dvi-document.c:521:49: warning: conversion from 'gdouble' {aka 'double'} to 'float' may change value [-Wfloat-conversion]
  521 |                         if (hsb2rgb (hsb[0], hsb[1], hsb[2], &red, &green, &blue))
      |                                              ~~~^~~
dvi-document.c:521:57: warning: conversion from 'gdouble' {aka 'double'} to 'float' may change value [-Wfloat-conversion]
  521 |                         if (hsb2rgb (hsb[0], hsb[1], hsb[2], &red, &green, &blue))
      |                                                      ~~~^~~
--
dvi-document.c:540:10: warning: conversion from 'double' to 'guchar' {aka 'unsigned char'} may change value [-Wfloat-conversion]
  540 |    red = r * 255 + 0.5;
      |          ^
dvi-document.c:541:12: warning: conversion from 'double' to 'guchar' {aka 'unsigned char'} may change value [-Wfloat-conversion]
  541 |    green = g * 255 + 0.5;
      |            ^
dvi-document.c:542:11: warning: conversion from 'double' to 'guchar' {aka 'unsigned char'} may change value [-Wfloat-conversion]
  542 |    blue = b * 255 + 0.5;
      |           ^
--
dvi-document.c:551:10: warning: conversion from 'double' to 'guchar' {aka 'unsigned char'} may change value [-Wfloat-conversion]
  551 |    rgb = gray * 255 + 0.5;
      |          ^~~~
--
dvi-document.c:560:11: warning: conversion from 'double' to 'guchar' {aka 'unsigned char'} may change value [-Wfloat-conversion]
  560 |     red = color.red * 255 / 65535.;
      |           ^~~~~
dvi-document.c:561:13: warning: conversion from 'double' to 'guchar' {aka 'unsigned char'} may change value [-Wfloat-conversion]
  561 |     green = color.green * 255 / 65535.;
      |             ^~~~~
dvi-document.c:562:12: warning: conversion from 'double' to 'guchar' {aka 'unsigned char'} may change value [-Wfloat-conversion]
  562 |     blue = color.blue * 255 / 65535.;
      |            ^~~~~
--
comics-document.c:789:39: warning: conversion from 'double' to 'int' may change value [-Wfloat-conversion]
  789 |         filename, width * (rc->scale) + 0.5,
      |                   ~~~~~~~~~~~~~~~~~~~~^~~~~
comics-document.c:790:30: warning: conversion from 'double' to 'int' may change value [-Wfloat-conversion]
  790 |         height * (rc->scale) + 0.5, NULL);
      |         ~~~~~~~~~~~~~~~~~~~~~^~~~~
--
comics-document.c:821:10: warning: conversion from 'double' to 'int' may change value [-Wfloat-conversion]
  821 |  int w = (width  * (*scale) + 0.5);
      |          ^
comics-document.c:822:10: warning: conversion from 'double' to 'int' may change value [-Wfloat-conversion]
  822 |  int h = (height * (*scale) + 0.5);
      |          ^
--
ev-annotation-window.c:234:32: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  234 |            event->button, event->x_root,
      |                           ~~~~~^~~~~~~~
ev-annotation-window.c:235:17: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  235 |            event->y_root, event->time);
      |            ~~~~~^~~~~~~~
--
ev-annotation-window.c:291:15: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  291 |   window->x = event->x_root - event->x;
      |               ^~~~~
ev-annotation-window.c:292:15: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  292 |   window->y = event->y_root - event->y;
      |               ^~~~~
--
ev-annotation-window.c:295:15: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  295 |          event->x_root,
      |          ~~~~~^~~~~~~~
ev-annotation-window.c:296:15: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  296 |          event->y_root,
      |          ~~~~~^~~~~~~~
--
ev-image-accessible.c:67:7: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
   67 |  *x = atk_rect.x1;
      |       ^~~~~~~~
ev-image-accessible.c:68:7: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
   68 |  *y = atk_rect.y1;
      |       ^~~~~~~~
ev-image-accessible.c:69:11: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
   69 |  *width = atk_rect.x2 - atk_rect.x1;
      |           ^~~~~~~~
ev-image-accessible.c:70:12: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
   70 |  *height = atk_rect.y2 - atk_rect.y1;
      |            ^~~~~~~~
--
ev-image-accessible.c:101:11: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  101 |  *width = atk_rect.x2 - atk_rect.x1;
      |           ^~~~~~~~
ev-image-accessible.c:102:12: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  102 |  *height = atk_rect.y2 - atk_rect.y1;
      |            ^~~~~~~~
--
ev-image-accessible.c:114:7: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  114 |  *x = atk_rect.x1;
      |       ^~~~~~~~
ev-image-accessible.c:115:7: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  115 |  *y = atk_rect.y1;
      |       ^~~~~~~~
--
ev-form-field-accessible.c:56:7: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
   56 |  *x = atk_rect.x1;
      |       ^~~~~~~~
ev-form-field-accessible.c:57:7: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
   57 |  *y = atk_rect.y1;
      |       ^~~~~~~~
ev-form-field-accessible.c:58:11: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
   58 |  *width = atk_rect.x2 - atk_rect.x1;
      |           ^~~~~~~~
ev-form-field-accessible.c:59:12: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
   59 |  *height = atk_rect.y2 - atk_rect.y1;
      |            ^~~~~~~~
--
ev-link-accessible.c:392:7: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  392 |  *x = atk_rect.x1;
      |       ^~~~~~~~
ev-link-accessible.c:393:7: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  393 |  *y = atk_rect.y1;
      |       ^~~~~~~~
ev-link-accessible.c:394:11: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  394 |  *width = atk_rect.x2 - atk_rect.x1;
      |           ^~~~~~~~
ev-link-accessible.c:395:12: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  395 |  *height = atk_rect.y2 - atk_rect.y1;
      |            ^~~~~~~~
--
ev-page-accessible.c:95:28: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
   95 |  return ABS (dy) > 10 ? dy : dx;
In file included from /usr/include/glib-2.0/glib/glist.h:32,
--
ev-page-accessible.c:1200:7: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 1200 |  *x = atk_rect.x1;
      |       ^~~~~~~~
ev-page-accessible.c:1201:7: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 1201 |  *y = atk_rect.y1;
      |       ^~~~~~~~
ev-page-accessible.c:1202:11: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 1202 |  *width = atk_rect.x2 - atk_rect.x1;
      |           ^~~~~~~~
ev-page-accessible.c:1203:12: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 1203 |  *height = atk_rect.y2 - atk_rect.y1;
      |            ^~~~~~~~
--
ev-pixbuf-cache.c:847:49: warning: conversion from 'gdouble' {aka 'double'} to 'gfloat' {aka 'float'} may change value [-Wfloat-conversion]
  847 |  ev_pixbuf_cache_clear_job_sizes (pixbuf_cache, scale);
      |                                                 ^~~~~
ev-pixbuf-cache.c:854:62: warning: conversion from 'gdouble' {aka 'double'} to 'gfloat' {aka 'float'} may change value [-Wfloat-conversion]
  854 |  ev_pixbuf_cache_add_jobs_if_needed (pixbuf_cache, rotation, scale);
      |                                                              ^~~~~
--
ev-pixbuf-cache.c:1349:35: warning: conversion from 'gdouble' {aka 'double'} to 'gfloat' {aka 'float'} may change value [-Wfloat-conversion]
 1349 |    width, height, page, rotation, scale,
      |                                   ^~~~~
--
/usr/include/glib-2.0/glib/gmacros.h:811:30: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                              ^
--
/usr/include/glib-2.0/glib/gmacros.h:811:30: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                              ^
--
ev-view.c:711:20: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  711 |   current_area.x = gtk_adjustment_get_value (view->hadjustment);
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~
ev-view.c:712:24: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  712 |   current_area.width = gtk_adjustment_get_page_size (view->hadjustment);
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
ev-view.c:713:20: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  713 |   current_area.y = gtk_adjustment_get_value (view->vadjustment);
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~
ev-view.c:714:25: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  714 |   current_area.height = gtk_adjustment_get_page_size (view->vadjustment);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
ev-view.c:897:11: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  897 |  rect.x = doc_rect.x1;
      |           ^~~~~~~~
ev-view.c:898:11: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  898 |  rect.y = doc_rect.y1;
      |           ^~~~~~~~
ev-view.c:899:15: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  899 |  rect.width = doc_rect.x2 - doc_rect.x1;
      |               ^~~~~~~~
--
/usr/include/glib-2.0/glib/gmacros.h:802:20: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  802 | #define MAX(a, b)  (((a) > (b)) ? (a) : (b))
      |                    ^
--
/usr/include/glib-2.0/glib/gmacros.h:802:20: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  802 | #define MAX(a, b)  (((a) > (b)) ? (a) : (b))
      |                    ^
--
/usr/include/glib-2.0/glib/gmacros.h:805:20: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  805 | #define MIN(a, b)  (((a) < (b)) ? (a) : (b))
      |                    ^
--
/usr/include/glib-2.0/glib/gmacros.h:802:20: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  802 | #define MAX(a, b)  (((a) > (b)) ? (a) : (b))
      |                    ^
--
/usr/include/glib-2.0/glib/gmacros.h:805:20: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
  805 | #define MIN(a, b)  (((a) < (b)) ? (a) : (b))
      |                    ^
--
ev-view.c:1350:18: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 1350 |  view_point->x = view_x + page_area.x;
      |                  ^~~~~~
ev-view.c:1351:18: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 1351 |  view_point->y = view_y + page_area.y;
      |                  ^~~~~~
--
ev-view.c:1393:17: warning: conversion from 'double' to 'int' may change value [-Wfloat-conversion]
 1393 |  view_rect->x = x * view->scale + page_area.x;
      |                 ^
ev-view.c:1394:17: warning: conversion from 'double' to 'int' may change value [-Wfloat-conversion]
 1394 |  view_rect->y = y * view->scale + page_area.y;
      |                 ^
ev-view.c:1395:21: warning: conversion from 'double' to 'int' may change value [-Wfloat-conversion]
 1395 |  view_rect->width = w * view->scale;
      |                     ^
ev-view.c:1396:22: warning: conversion from 'double' to 'int' may change value [-Wfloat-conversion]
 1396 |  view_rect->height = h * view->scale;
      |                      ^
--
ev-view.c:1428:16: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 1428 |    *x_offset = x - (page_area.x + border.left);
      |                ^
ev-view.c:1429:16: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 1429 |    *y_offset = y - (page_area.y + border.top);
      |                ^
--
ev-view.c:1454:56: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
 1454 |   return cairo_region_contains_point (region, x_offset / view->scale, y_offset / view->scale);
      |                                               ~~~~~~~~~^~~~~~~~~~~~~
ev-view.c:1454:80: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
 1454 |   return cairo_region_contains_point (region, x_offset / view->scale, y_offset / view->scale);
      |                                                                       ~~~~~~~~~^~~~~~~~~~~~~
--
ev-view.c:1473:79: warning: conversion from 'gdouble' {aka 'double'} to 'gfloat' {aka 'float'} may change value [-Wfloat-conversion]
 1473 |  region = ev_pixbuf_cache_get_selection_region (view->pixbuf_cache, page, view->scale);
      |                                                                           ~~~~^~~~~~~
--
ev-view.c:1494:13: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 1494 |  x_offset = x_offset / view->scale;
      |             ^~~~~~~~
ev-view.c:1495:13: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 1495 |  y_offset = y_offset / view->scale;
      |             ^~~~~~~~
ev-view.c:1513:11: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 1513 |  *x_new = x;
      |           ^
ev-view.c:1514:11: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 1514 |  *y_new = y;
      |           ^
--
ev-view.c:3265:88: warning: conversion from 'gdouble' {aka 'double'} to 'gfloat' {aka 'float'} may change value [-Wfloat-conversion]
 3265 |      !ev_pixbuf_cache_get_selection_region (view->pixbuf_cache, view->cursor_page, view->scale)) {
      |                                                                                    ~~~~^~~~~~~
--
ev-view.c:3352:15: warning: conversion from 'gfloat' {aka 'float'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 3352 |  stem_width = area->height * cursor_aspect_ratio + 1;
      |               ^~~~
--
ev-view.c:4014:72: warning: conversion from 'gdouble' {aka 'double'} to 'gfloat' {aka 'float'} may change value [-Wfloat-conversion]
 4014 |   !ev_pixbuf_cache_get_selection_region (view->pixbuf_cache, page, view->scale));
      |                                                                    ~~~~^~~~~~~
--
ev-view.c:4262:33: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4262 |  view->selection_info.start.x = event->x + view->scroll_x;
      |                                 ^~~~~
ev-view.c:4263:33: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4263 |  view->selection_info.start.y = event->y + view->scroll_y;
      |                                 ^~~~~
--
ev-view.c:4317:13: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4317 |       dx1 = doc_x - last->x2;
      |             ^~~~~
ev-view.c:4318:13: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4318 |       dx2 = rect->x1 - doc_x;
      |             ^~~~
--
ev-view.c:4492:20: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4492 |      end_point.x = event->x + view->scroll_x;
      |                    ^~~~~
ev-view.c:4493:20: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4493 |      end_point.y = event->y + view->scroll_y;
      |                    ^~~~~
ev-view.c:4520:36: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4520 |     view->image_dnd_info.start.x = event->x + view->scroll_x;
      |                                    ^~~~~
ev-view.c:4521:36: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4521 |     view->image_dnd_info.start.y = event->y + view->scroll_y;
      |                                    ^~~~~
ev-view.c:4545:30: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4545 |    view->drag_info.start.x = event->x_root;
      |                              ^~~~~
ev-view.c:4546:30: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4546 |    view->drag_info.start.y = event->y_root;
      |                              ^~~~~
ev-view.c:4554:32: warning: conversion from 'gdouble' {aka 'double'} to 'guint' {aka 'unsigned int'} may change value [-Wfloat-conversion]
 4554 |    view->scroll_info.start_y = event->y;
      |                                ^~~~~
--
ev-view.c:4729:32: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4729 |  view->drag_info.momentum.x /= 1.2;
      |                                ^~~
ev-view.c:4730:32: warning: conversion from 'double' to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4730 |  view->drag_info.momentum.y /= 1.2; /* Alter these constants to change "friction" */
      |                                ^~~
--
ev-view.c:4790:10: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4790 |      x = event->x;
      |          ^~~~~
ev-view.c:4791:10: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4791 |      y = event->y;
      |          ^~~~~
--
ev-view.c:4811:28: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4811 |                       event->x,
      |                       ~~~~~^~~
ev-view.c:4812:28: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4812 |                       event->y);
      |                       ~~~~~^~~
ev-view.c:4834:28: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4834 |                       event->x,
      |                       ~~~~~^~~
ev-view.c:4835:28: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4835 |                       event->y);
      |                       ~~~~~^~~
ev-view.c:4883:15: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4883 |          event->x_root,
      |          ~~~~~^~~~~~~~
ev-view.c:4884:15: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4884 |          event->y_root);
      |          ~~~~~^~~~~~~~
ev-view.c:4891:35: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4891 |     view->drag_info.buffer[i].x = event->x;
      |                                   ^~~~~
ev-view.c:4892:35: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4892 |     view->drag_info.buffer[i].y = event->y;
      |                                   ^~~~~
ev-view.c:4903:34: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4903 |    view->drag_info.buffer[0].x = event->x;
      |                                  ^~~~~
ev-view.c:4904:34: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4904 |    view->drag_info.buffer[0].y = event->y;
      |                                  ^~~~~
ev-view.c:4906:9: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
 4906 |    dx = event->x_root - view->drag_info.start.x;
      |         ^~~~~
ev-view.c:4907:9: warning: conversion from 'gdouble' {aka 'double'} to 'int' may change value [-Wfloat-conversion]
 4907 |    dy = event->y_root - view->drag_info.start.y;
      |         ^~~~~
--
ev-view.c:4975:45: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4975 |   ev_view_handle_cursor_over_xy (view, event->x, event->y);
      |                                        ~~~~~^~~
ev-view.c:4975:55: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4975 |   ev_view_handle_cursor_over_xy (view, event->x, event->y);
      |                                                  ~~~~~^~~
ev-view.c:4980:18: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4980 |         event->x + view->scroll_x,
      |         ~~~~~~~~~^~~~~~~~~~~~~~~~
ev-view.c:4981:18: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4981 |         event->y + view->scroll_y);
      |         ~~~~~~~~~^~~~~~~~~~~~~~~~
ev-view.c:4987:45: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4987 |   ev_view_handle_cursor_over_xy (view, event->x, event->y);
      |                                        ~~~~~^~~
ev-view.c:4987:55: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 4987 |   ev_view_handle_cursor_over_xy (view, event->x, event->y);
      |                                                  ~~~~~^~~
--
ev-view.c:5612:44: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 5612 |  ev_view_handle_cursor_over_xy (view, event->x, event->y);
      |                                       ~~~~~^~~
ev-view.c:5612:54: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 5612 |  ev_view_handle_cursor_over_xy (view, event->x, event->y);
      |                                                 ~~~~~^~~
--
ev-view.c:5736:15: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 5736 |   offset_x /= scale_x;
      |               ^~~~~~~
ev-view.c:5737:15: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
 5737 |   offset_y /= scale_y;
      |               ^~~~~~~
--
ev-view.c:5866:66: warning: conversion from 'gdouble' {aka 'double'} to 'gfloat' {aka 'float'} may change value [-Wfloat-conversion]
 5866 |                                                              view->scale);
      |                                                              ~~~~^~~~~~~
ev-view.c:5875:54: warning: conversion from 'gdouble' {aka 'double'} to 'gfloat' {aka 'float'} may change value [-Wfloat-conversion]
 5875 |                                                  view->scale);
      |                                                  ~~~~^~~~~~~
--
ev-view.c:7775:59: warning: conversion from 'gdouble' {aka 'double'} to 'gfloat' {aka 'float'} may change value [-Wfloat-conversion]
 7775 |                                                       view->scale);
      |                                                       ~~~~^~~~~~~
--
ev-view-accessible.c:556:6: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  556 |  x = gtk_adjustment_get_value (view->hadjustment);
      |      ^~~~~~~~~~~~~~~~~~~~~~~~
ev-view-accessible.c:557:6: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  557 |  y = gtk_adjustment_get_value (view->vadjustment);
      |      ^~~~~~~~~~~~~~~~~~~~~~~~
--
../cut-n-paste/zoom-control/ephy-zoom.h:54:15: warning: conversion from 'double' to 'float' changes value from '7.0710678110000003e-1' to '7.07106769e-1f' [-Wfloat-conversion]
   54 |  { N_("70%"), 0.7071067811 },
      |               ^~~~~~~~~~~~
../cut-n-paste/zoom-control/ephy-zoom.h:55:15: warning: conversion from 'double' to 'float' changes value from '8.4089641520000002e-1' to '8.40896428e-1f' [-Wfloat-conversion]
   55 |  { N_("85%"), 0.8408964152 },
      |               ^~~~~~~~~~~~
../cut-n-paste/zoom-control/ephy-zoom.h:57:16: warning: conversion from 'double' to 'float' changes value from '1.1892071149000001e+0' to '1.18920708e+0f' [-Wfloat-conversion]
   57 |  { N_("125%"), 1.1892071149 },
      |                ^~~~~~~~~~~~
../cut-n-paste/zoom-control/ephy-zoom.h:58:16: warning: conversion from 'double' to 'float' changes value from '1.4142135623000001e+0' to '1.41421354e+0f' [-Wfloat-conversion]
   58 |  { N_("150%"), 1.4142135623 },
      |                ^~~~~~~~~~~~
../cut-n-paste/zoom-control/ephy-zoom.h:59:16: warning: conversion from 'double' to 'float' changes value from '1.6817928304e+0' to '1.68179286e+0f' [-Wfloat-conversion]
   59 |  { N_("175%"), 1.6817928304 },
      |                ^~~~~~~~~~~~
../cut-n-paste/zoom-control/ephy-zoom.h:61:16: warning: conversion from 'double' to 'float' changes value from '2.8284271247000001e+0' to '2.82842708e+0f' [-Wfloat-conversion]
   61 |  { N_("300%"), 2.8284271247 },
      |                ^~~~~~~~~~~~
--
ev-window.c:646:15: warning: conversion from 'gdouble' {aka 'double'} to 'float' may change value [-Wfloat-conversion]
  646 |   real_zoom = ev_document_model_get_scale (ev_window->priv->model);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
ev-window.c:647:16: warning: conversion from 'double' to 'float' may change value [-Wfloat-conversion]
  647 |   real_zoom *= 72.0 / get_monitor_dpi (ev_window);
      |                ^~~~
--
ev-window.c:905:39: warning: conversion from 'double' to 'guint' {aka 'unsigned int'} changes value from '5.0e-1' to '0' [-Wfloat-conversion]
  905 |   g_timeout_add_full (G_PRIORITY_LOW, 0.5, (GSourceFunc)show_loading_message_cb, window, NULL);
      |                                       ^~~
--
ev-window.c:4628:76: warning: conversion from 'gdouble' {aka 'double'} to 'float' may change value [-Wfloat-conversion]
 4628 |  ephy_zoom_action_set_max_zoom_level (EPHY_ZOOM_ACTION (action), max_scale * dpi);
      |                                                                  ~~~~~~~~~~^~~~~
--
ev-sidebar-attachments.c:289:20: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  289 |               event->x,
      |               ~~~~~^~~
ev-sidebar-attachments.c:290:20: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  290 |               event->y);
      |               ~~~~~^~~
ev-sidebar-attachments.c:310:70: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  310 |    return ev_sidebar_attachments_popup_menu_show (ev_attachbar, event->x, event->y);
      |                                                                 ~~~~~^~~
ev-sidebar-attachments.c:310:80: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  310 |    return ev_sidebar_attachments_popup_menu_show (ev_attachbar, event->x, event->y);
      |                                                                           ~~~~~^~~
--
ev-sidebar-bookmarks.c:370:78: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  370 |         return ev_sidebar_bookmarks_popup_menu_show (sidebar_bookmarks, event->x, event->y, FALSE);
      |                                                                         ~~~~~^~~
ev-sidebar-bookmarks.c:370:88: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  370 |         return ev_sidebar_bookmarks_popup_menu_show (sidebar_bookmarks, event->x, event->y, FALSE);
      |                                                                                   ~~~~~^~~
--
ev-sidebar-links.c:358:50: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  358 |                                             event->x,
      |                                             ~~~~~^~~
ev-sidebar-links.c:359:50: warning: conversion from 'gdouble' {aka 'double'} to 'gint' {aka 'int'} may change value [-Wfloat-conversion]
  359 |                                             event->y,
      |                                             ~~~~~^~~
```