### PR TITLE
check return value of xmlDocGetRootElement call if is NULL

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -181,8 +181,18 @@ epub_document_check_hits(EvDocumentFind *document_find,
 {
 	gchar *filepath = g_filename_from_uri((gchar*)page->backend_page,NULL,NULL);
 	htmlDocPtr htmldoc =  xmlParseFile(filepath);
-	htmlNodePtr htmltag = xmlDocGetRootElement(htmldoc);
-	int count=0;
+    if (htmldoc == NULL) {
+        g_free(filepath);
+        return 0;
+    }
+    htmlNodePtr htmltag = xmlDocGetRootElement(htmldoc);
+    if (htmltag == NULL) {
+        g_free(filepath);
+        xmlFreeDoc (htmldoc);
+        return 0;
+    }
+
+    int count=0;
 	htmlNodePtr bodytag = htmltag->xmlChildrenNode;
 
 	while ( xmlStrcmp(bodytag->name,(xmlChar*)"body") ) {

--- a/cut-n-paste/toolbar-editor/egg-toolbars-model.c
+++ b/cut-n-paste/toolbar-editor/egg-toolbars-model.c
@@ -597,7 +597,12 @@ egg_toolbars_model_load_toolbars (EggToolbarsModel *model,
     return FALSE;
   }
   root = xmlDocGetRootElement (doc);
-
+  if (root == NULL)
+  {
+    g_warning ("Failed to get root element");
+    xmlFreeDoc (doc);
+    return FALSE;
+  }
   parse_toolbars (model, root->children);
 
   xmlFreeDoc (doc);
@@ -627,6 +632,8 @@ egg_toolbars_model_load_toolbars_from_resource (EggToolbarsModel *model,
     g_error ("Failed to load XML data from resource %s", path);
 
   root = xmlDocGetRootElement (doc);
+  if (root == NULL)
+    g_error ("Failed to get root element");
   parse_toolbars (model, root->children);
 
   xmlFreeDoc (doc);
@@ -691,6 +698,12 @@ egg_toolbars_model_load_names (EggToolbarsModel *model,
     return FALSE;
   }
   root = xmlDocGetRootElement (doc);
+  if (root == NULL)
+  {
+    g_warning ("Failed to get root element");
+    xmlFreeDoc (doc);
+    return FALSE;
+  }
 
   parse_names (model, root->children);
 
@@ -721,6 +734,8 @@ egg_toolbars_model_load_names_from_resource (EggToolbarsModel *model,
     g_error ("Failed to load XML data from resource %s", path);
 
   root = xmlDocGetRootElement (doc);
+  if (root == NULL)
+    g_error ("Failed to get root element");
   parse_names (model, root->children);
 
   xmlFreeDoc (doc);


### PR DESCRIPTION
Fix for missing xmlDocGetRootElement() check problem in #485 