### PR TITLE
ev-sidebar-attachments: do not add add a Gtk_Container

### DIFF
--- a/shell/ev-sidebar-attachments.c
+++ b/shell/ev-sidebar-attachments.c
@@ -566,8 +566,7 @@ ev_sidebar_attachments_init (EvSidebarAttachments *ev_attachbar)
 			   ev_attachbar->priv->icon_view);
 
 	gtk_box_pack_start (GTK_BOX (ev_attachbar), swindow, TRUE, TRUE, 0);
-	gtk_container_add (GTK_CONTAINER (ev_attachbar),
-			   swindow);
+
 	gtk_widget_show_all (GTK_WIDGET (ev_attachbar));
 
 	/* Icon Theme */


### PR DESCRIPTION
Fixes a runtime warning caused by
https://github.com/mate-desktop/atril/commit/70f42da
See https://github.com/mate-desktop/atril/pull/476#issuecomment-667701035
for more info.