### PR TITLE
Typo in fr.po

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -1752,7 +1752,7 @@ msgstr "Affiche le document comme une présentation"
 
 #: shell/ev-window.c:6631
 msgid "Inverted _Colors"
-msgstr "Couleurs_inversées"
+msgstr "Couleurs _inversées"
 
 #: shell/ev-window.c:6632
 msgid "Show page contents with the colors inverted"


### PR DESCRIPTION
Just updating a typo in `fr.po`. Is mate using transiflex? I can't find mate there, only the teams.