### PR TITLE
epub backend: Escape link text to display & in index content

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -265,7 +265,7 @@ epub_document_make_tree_entry(linknode* ListData,LinksCBStruct* UserData)
     link = ev_link_new((gchar*)ListData->linktext,ev_action);
 
     gtk_tree_store_append (GTK_TREE_STORE (UserData->model), &tree_iter,(UserData->parent));
-    title_markup = g_strdup((gchar*)ListData->linktext);
+    title_markup = g_markup_escape_text ((gchar*)ListData->linktext, -1);
 
     gtk_tree_store_set (GTK_TREE_STORE (UserData->model), &tree_iter,
                         EV_DOCUMENT_LINKS_COLUMN_MARKUP, title_markup,

--- a/help/reference/libdocument/Makefile.am
+++ b/help/reference/libdocument/Makefile.am
@@ -123,6 +123,8 @@ EXTRA_DIST += \
 # for --rebuild-sections in $(SCAN_OPTIONS) e.g. $(DOC_MODULE)-sections.txt
 #DISTCLEANFILES +=
 
+DISTCLEANFILES = $(DOC_MODULE).actions
+
 # Comment this out if you want your docs-status tested during 'make check'
 if ENABLE_GTK_DOC
 #TESTS_ENVIRONMENT = cd $(srcsrc) &&

--- a/help/reference/libview/Makefile.am
+++ b/help/reference/libview/Makefile.am
@@ -133,6 +133,8 @@ EXTRA_DIST += \
 # for --rebuild-sections in $(SCAN_OPTIONS) e.g. $(DOC_MODULE)-sections.txt
 #DISTCLEANFILES +=
 
+DISTCLEANFILES = $(DOC_MODULE).actions
+
 # Comment this out if you want your docs-status tested during 'make check'
 if ENABLE_GTK_DOC
 #TESTS_ENVIRONMENT = cd $(srcsrc) &&

--- a/help/reference/shell/Makefile.am
+++ b/help/reference/shell/Makefile.am
@@ -138,6 +138,8 @@ EXTRA_DIST += \
 # for --rebuild-sections in $(SCAN_OPTIONS) e.g. $(DOC_MODULE)-sections.txt
 #DISTCLEANFILES +=
 
+DISTCLEANFILES = $(DOC_MODULE).actions
+
 # Comment this out if you want your docs-status tested during 'make check'
 if ENABLE_GTK_DOC
 #TESTS_ENVIRONMENT = cd $(srcsrc) &&


### PR DESCRIPTION
Closes #495
```
(atril:2235): Gtk-WARNING **: 14:13:45.580: Failed to set text from markup due to error parsing markup: Error on line 1: Entity did not end with a semicolon; most likely you used an ampersand character without intending to start an entity — escape ampersand as &amp;
```