### PR TITLE
Remove warning -Wtype-limits

### DIFF
--- a/backend/dvi/mdvi-lib/dviread.c
+++ b/backend/dvi/mdvi-lib/dviread.c
@@ -614,8 +614,6 @@ int mdvi_configure(DviContext *dvi, DviParamCode option, ...)
 		return -1;
 	if(np.mag <= 0.0)
 		return -1;
-	if(np.density < 0)
-		return -1;
 	if(np.hshrink < 1 || np.vshrink < 1)
 		return -1;
 	if(np.hdrift < 0 || np.vdrift < 0)

--- a/libview/ev-view-presentation.c
+++ b/libview/ev-view-presentation.c
@@ -425,7 +425,7 @@ ev_view_presentation_update_current_page (EvViewPresentation *pview,
 {
 	gint jump;
 
-	if (page < 0 || page >= ev_document_get_n_pages (pview->document))
+	if (page >= ev_document_get_n_pages (pview->document))
 		return;
 
 	ev_view_presentation_animation_cancel (pview);


### PR DESCRIPTION
```
atril.make.log:dviread.c:617:16: warning: comparison of unsigned expression in '< 0' is always false [-Wtype-limits]
atril.make.log-  617 |  if(np.density < 0)
atril.make.log-      |                ^
--
atril.make.log:ev-view-presentation.c:428:11: warning: comparison of unsigned expression in '< 0' is always false [-Wtype-limits]
atril.make.log-  428 |  if (page < 0 || page >= ev_document_get_n_pages (pview->document))
atril.make.log-      |           ^
```