### PR TITLE
ps backend: do not silence the warnings when rendering the page

### DIFF
--- a/backend/ps/ev-spectre.c
+++ b/backend/ps/ev-spectre.c
@@ -315,14 +315,14 @@ ps_document_render (EvDocument      *document,
 	spectre_page_render (ps_page, src, &data, &stride);
 	spectre_render_context_free (src);
 
-	if (!data) {
+	if (spectre_page_status (ps_page) != SPECTRE_STATUS_SUCCESS) {
+		g_warning ("libspectre reports: %s",
+		           spectre_status_to_string (spectre_page_status (ps_page)));
+		g_free (data);
 		return NULL;
 	}
 
-	if (spectre_page_status (ps_page)) {
-		g_warning ("%s", spectre_status_to_string (spectre_page_status (ps_page)));
-		g_free (data);
-
+	if (!data) {
 		return NULL;
 	}
 


### PR DESCRIPTION
test #506

before
```
$ atril ~/Documents/ptc40.ps
(libspectre) ghostscript reports: undefined -21
Segmentation fault (core dumped)
```
after
```
$ atril ~/Documents/ptc40.ps
(libspectre) ghostscript reports: undefined -21

** (atril:325985): WARNING **: 21:08:44.687: libspectre reports: render error
Segmentation fault (core dumped)
```