### PR TITLE
build: Use PACKAGE_URL variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,13 @@ m4_define([ev_binary_version], [ev_document_lt_current])
 # *****************************************************************************
 
 AC_PREREQ([2.57])
-AC_INIT([atril], [ev_version], [https://mate-desktop.org/], [atril])
+
+AC_INIT([atril],
+        [ev_version],
+        [https://github.com/mate-desktop/atril/issues],
+        [atril],
+        [https://mate-desktop.org])
+
 AM_INIT_AUTOMAKE([1.10 foreign tar-ustar dist-xz no-dist-gzip check-news])
 
 AC_CONFIG_HEADERS([config.h])
@@ -717,6 +723,7 @@ cut-n-paste/smclient/Makefile
 cut-n-paste/smclient/libegg/Makefile
 cut-n-paste/toolbar-editor/Makefile
 cut-n-paste/zoom-control/Makefile
+data/atril.appdata.xml.in
 data/atril.desktop.in
 data/Makefile
 data/icons/Makefile

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -14,24 +14,23 @@ man_MANS=atril.1
 #
 
 uidir = $(pkgdatadir)
-ui_DATA =				\
+ui_DATA = \
 	hand-open.png
 
 #
 # Desktop file
 #
 
-DESKTOP_IN_FILES = atril.desktop.in
-DESKTOP_FILES = $(DESKTOP_IN_FILES:.desktop.in=.desktop)
-
 desktopdir = $(datadir)/applications
-desktop_DATA = $(DESKTOP_FILES)
-$(desktop_DATA): $(DESKTOP_IN_FILES)
+desktop_in_files = atril.desktop.in
+desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
+$(desktop_DATA): $(desktop_in_files)
 	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 #
 # DBus servide file
 #
+
 if ENABLE_DBUS
 servicedir = $(datadir)/dbus-1/services
 service_in_files = org.mate.atril.Daemon.service.in
@@ -44,8 +43,10 @@ endif
 #
 # App data file
 #
+
 appdatadir = $(datadir)/metainfo
-appdata_in_files = atril.appdata.xml.in
+appdata_in_in_files = atril.appdata.xml.in.in
+appdata_in_files = $(appdata_in_in_files:.appdata.xml.in.in=.appdata.xml.in)
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 $(appdata_DATA): $(appdata_in_files)
 	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
@@ -53,13 +54,13 @@ $(appdata_DATA): $(appdata_in_files)
 #
 # GSettings schema
 #
+
 gsettings_SCHEMAS = org.mate.Atril.gschema.xml
 
 .PRECIOUS: $(gsettings_SCHEMAS)
 
 # include the appropriate makefile rules for schema handling
 @GSETTINGS_RULES@
-
 
 #
 # GTK icon cache
@@ -79,18 +80,18 @@ update-icon-cache:
 	        echo "***   $(gtk_update_icon_cache)"; \
 	        fi
 
-
 #
 # Extra files to be included in the tarball
 #
 
 EXTRA_DIST =					\
-	$(ui_DATA)				\
-	$(DESKTOP_IN_FILES)			\
-	$(appdata_in_files)			\
+	$(appdata_in_in_files)			\
+	$(desktop_in_files)			\
 	$(gsettings_SCHEMAS)			\
-	org.mate.atril.Daemon.service.in	\
 	$(man_MANS)				\
+	$(service_in_files)			\
+	$(ui_DATA)				\
+	org.mate.atril.Daemon.service.in	\
 	$(NULL)
 
 #
@@ -98,10 +99,13 @@ EXTRA_DIST =					\
 #
 
 CLEANFILES = \
-	atril.appdata.xml
+	$(appdata_DATA)		\
+	$(desktop_DATA)		\
+	$(service_DATA)		\
+	$(NULL)
 
 DISTCLEANFILES = \
-	$(DESKTOP_FILES)	\
-	$(service_DATA)
+	$(appdata_in_files)	\
+	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/data/atril.appdata.xml.in.in
+++ b/data/atril.appdata.xml.in.in
@@ -38,7 +38,7 @@
    </image>
   </screenshot>
  </screenshots>
- <url type="homepage">https://mate-desktop.org</url>
+ <url type="homepage">@PACKAGE_URL@</url>
  <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
  <project_group>MATE</project_group>
 </component>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -24,14 +24,14 @@ cut-n-paste/smclient/libegg/eggsmclient.c
 cut-n-paste/toolbar-editor/egg-editable-toolbar.c
 cut-n-paste/toolbar-editor/egg-toolbar-editor.c
 cut-n-paste/zoom-control/ephy-zoom.h
-data/atril.appdata.xml.in
+data/atril.appdata.xml.in.in
 data/atril.desktop.in.in
 data/org.mate.Atril.gschema.xml
 previewer/ev-previewer.c
 previewer/ev-previewer-window.c
 properties/ev-properties-main.c
 properties/ev-properties-view.c
-properties/libatril-properties-page.caja-extension.desktop.in
+properties/libatril-properties-page.caja-extension.desktop.in.in
 libmisc/ev-page-action.c
 libmisc/ev-page-action-widget.c
 libview/ev-print-operation.c

--- a/properties/Makefile.am
+++ b/properties/Makefile.am
@@ -4,7 +4,7 @@ AM_CPPFLAGS=					\
 	-I$(top_srcdir)				\
 	-I$(top_builddir)			\
 	$(FRONTEND_CFLAGS)			\
-	$(CAJA_CFLAGS)			\
+	$(CAJA_CFLAGS)				\
 	$(DISABLE_DEPRECATED)			\
 	$(WARN_CFLAGS)
 
@@ -19,7 +19,7 @@ if ENABLE_CAJA
 cajaextension_LTLIBRARIES = libatril-properties-page.la
 
 libatril_properties_page_la_CFLAGS = -I$(top_srcdir)
-libatril_properties_page_la_SOURCES = 	\
+libatril_properties_page_la_SOURCES =		\
 	ev-properties-main.c
 
 libatril_properties_page_la_LIBADD = 		\
@@ -31,13 +31,15 @@ libatril_properties_page_la_LIBADD = 		\
 libatril_properties_page_la_LDFLAGS = -module -avoid-version -no-undefined
 
 extensiondir = $(datadir)/caja/extensions
-extension_in_files = libatril-properties-page.caja-extension.desktop.in
+extension_in_in_files = libatril-properties-page.caja-extension.desktop.in.in
+extension_in_files = $(extension_in_in_files:.caja-extension.desktop.in.in=.caja-extension.desktop.in)
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
-EXTRA_DIST = $(extension_in_files)
+EXTRA_DIST = $(extension_in_in_files)
 
+DISTCLEANFILES = $(extension_in_files)
 CLEANFILES = $(extension_DATA)
 
 endif # ENABLE_CAJA

--- a/properties/libatril-properties-page.caja-extension.desktop.in.in
+++ b/properties/libatril-properties-page.caja-extension.desktop.in.in
@@ -5,5 +5,5 @@ Name=Atril properties
 Description=Shows details for Atril documents
 Version=@VERSION@
 Author=Andrew Sobala <aes@gnome.org>;Bastien Nocera <hadess@hadess.net>
-Website=https://mate-desktop.org/
+Website=@PACKAGE_URL@
 Copyright=Copyright (C) 2000, 2001 Eazel Inc.\nCopyright (C) 2003 Andrew Sobala <aes@gnome.org>\nCopyright (C) 2005 Bastien Nocera <hadess@hadess.net>\nCopyright (C) 2005 Red Hat, Inc\nCopyright (C) 2012–2018 The MATE developers

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -5446,7 +5446,7 @@ ev_window_cmd_help_about (GtkAction *action, EvWindow *ev_window)
 		"copyright", _("Copyright \xc2\xa9 1996–2009 The Evince authors\n"
 		               "Copyright \xc2\xa9 2012–2021 The MATE developers"),
 		"license", license_trans,
-		"website", "https://mate-desktop.org/",
+		"website", PACKAGE_URL,
 		"comments", comments,
 		"authors", authors,
 		"documenters", documenters,


### PR DESCRIPTION
Test:
```
$ grep homepage data/atril.appdata.xml
  <url type="homepage">https://mate-desktop.org</url>
$ grep Website properties/libatril-properties-page.caja-extension
Website=https://mate-desktop.org
$ grep PACKAGE_URL config.h
#define PACKAGE_URL "https://mate-desktop.org"
```

- Fix build error (po/POTFILES.in):
```
make[6]: *** No rule to make target '../../../properties/libatril-properties-page.caja-extension.desktop.in', needed by 'atril.pot-update'.  Stop.
make[6]: Leaving directory '/home/robert/atril/atril-1.25.0/_build/sub/po'
make[5]: *** [Makefile:589: update-po] Error 2
make[5]: Leaving directory '/home/robert/atril/atril-1.25.0/_build/sub/po'
make[4]: *** [Makefile:555: distdir] Error 2
make[4]: Leaving directory '/home/robert/atril/atril-1.25.0/_build/sub/po'
make[3]: *** [Makefile:763: distdir-am] Error 1
make[3]: Leaving directory '/home/robert/atril/atril-1.25.0/_build/sub'
make[2]: *** [Makefile:756: distdir] Error 2
make[2]: Leaving directory '/home/robert/atril/atril-1.25.0/_build/sub'
make[1]: *** [Makefile:867: dist] Error 2
make[1]: Leaving directory '/home/robert/atril/atril-1.25.0/_build/sub'
make: *** [Makefile:879: distcheck] Error 1
```

- Set all [AC_INIT](https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Initializing-configure.html) fields including optional ones (configure.ac):
```
Macro: AC_INIT (package, version, [bug-report], [tarname], [url])
```

- Sort the variables alphabetically (data/Makefile.am)
- Write the variables `DESKTOP_*` in lower case (data/Makefile.am)
- Add `$(service_in_files)` in `EXTRA_DIST` (data/Makefile.am)