### PR TITLE
build: display package name and version in configure summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -772,6 +772,9 @@ AC_OUTPUT
 echo "
 Configure summary:
 
+    ${PACKAGE_STRING}
+    `echo $PACKAGE_STRING | sed "s/./=/g"`
+
     prefix..............:    ${prefix}
     compiler............:    ${CC}
     cflags..............:    ${CFLAGS}


### PR DESCRIPTION
```
$ ./autogen.sh --prefix=/usr
<cut>
Configure summary:

    atril 1.25.0
    ============

    prefix..............:    /usr
    compiler............:    gcc
    cflags..............:    -g -O2
    warning flags.......:    -Wall -Wmissing-prototypes

    GTK+ Unix Print.....:    yes
    Keyring Support.....:    yes
    DBUS Support........:    yes
    Caja Plugin.........:    yes
    Thumbnailer.........:    yes
    Previewer...........:    yes
    Gtk-Doc Support.....:    no
    Debug mode..........:    no
    GObj. Introspection.:    no
    Tests...............:    yes

    PDF Backend.........:    yes
    Synctex enabled.....:    yes
    PostScript Backend..:    yes
    TIFF Backend........:    yes
    DJVU Backend........:    yes
    DVI Backend.........:    yes
    Pixbuf Backend......:    no
    Comics Backend......:    yes
    XPS Backend.........:    yes
    ePub Backend........:    yes

Now type `make' to compile atril
```