### PR TITLE
introspection: Fix bogus --library arguments.

### DIFF
--- a/libdocument/Makefile.am
+++ b/libdocument/Makefile.am
@@ -168,7 +168,7 @@ AtrilDocument-$(EV_API_VERSION).gir: libatrildocument.la Makefile $(INST_H_FILES
 	--include=Gdk-3.0 \
 	--include=GdkPixbuf-2.0 \
 	--include=Gtk-3.0 \
-	--library=atrildocument \
+	--library=libatrildocument.la \
 	--libtool="$(LIBTOOL)" \
 	--output $@ \
 	--pkg atril-document-$(EV_API_VERSION) \

--- a/libview/Makefile.am
+++ b/libview/Makefile.am
@@ -141,7 +141,7 @@ AtrilView-$(EV_API_VERSION).gir: libatrilview.la Makefile $(INST_H_FILES) $(filt
 	--include=GdkPixbuf-2.0 \
 	--include=Gtk-3.0 \
 	--include=AtrilDocument-$(EV_API_VERSION) \
-	--library=atrilview \
+	--library=libatrilview.la \
 	--libtool="$(LIBTOOL)" \
 	--output $@ \
 	--pkg atril-document-$(EV_API_VERSION) \


### PR DESCRIPTION
When building atril with `--enable-introspection` and slibtool (https://dev.midipix.org/cross/slibtool) it fails.
```
rdlibtool --mode=execute ldd /tmp/atril/libdocument/tmp-introspectx_ramcgd/AtrilDocument-1.5.0

rdlibtool: lconf: {.name="libtool"}.
rdlibtool: fdcwd: {.fdcwd=AT_FDCWD, .realpath="/tmp/atril/libdocument"}.
rdlibtool: lconf: fstatat(AT_FDCWD,".",...) = 0 {.st_dev = 45, .st_ino = 78493}.
rdlibtool: lconf: openat(AT_FDCWD,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(AT_FDCWD,"../",O_DIRECTORY,0) = 3.
rdlibtool: lconf: fstat(3,...) = 0 {.st_dev = 45, .st_ino = 77854}.
rdlibtool: lconf: openat(3,"libtool",O_RDONLY,0) = 4.
rdlibtool: lconf: found "/tmp/atril/libtool".
/tmp/atril/libdocument/tmp-introspectx_ramcgd/.libs/AtrilDocument-1.5.0: error while loading shared libraries: libatrildocument.so.3: cannot open shared object file: No such file or directory
Command '['/tmp/atril/libdocument/tmp-introspectx_ramcgd/AtrilDocument-1.5.0', '--introspect-dump=/tmp/atril/libdocument/tmp-introspectx_ramcgd/functions.txt,/tmp/atril/libdocument/tmp-introspectx_ramcgd/dump.xml']' returned non-zero exit status 127.
make[2]: *** [Makefile:1446: AtrilDocument-1.5.0.gir] Error 1
make[2]: Leaving directory '/tmp/atril/libdocument'
make[1]: *** [Makefile:1228: install] Error 2
make[1]: Leaving directory '/tmp/atril/libdocument'
make: *** [Makefile:660: install-recursive] Error 1
```
This is because atril has custom `g-ir-scanner` targets and passes bogus input to `--library`.  The expected input is the libtool archive (`.la`) file which show the `$(LIBTOOL)` implementation where the dependencies are.

Looking at the gnome documentation it shows:
> LIBS - Library where the symbol represented in the gir can be found
https://wiki.gnome.org/Projects/GObjectIntrospection/AutotoolsIntegration

And looking at `/usr/share/gobject-introspection-1.0/Makefile.introspection`:
```
_gir_libraries = $(foreach lib,$($(_gir_name)_LIBS),--library=$(lib))
```
I am not sure how GNU libtool is avoiding this, but regardless atril should just pass the correct input to `g-ir-scanner` and then both implementations work.

Note: This only occurs if atril is not yet installed.
