### PR TITLE
Trust the file extension for EPUBs, fixes mate-desktop/atril#325

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -624,7 +624,7 @@ static gboolean
 check_mime_type(const gchar* uri,GError** error)
 {
     GError * err = NULL ;
-    const gchar* mimeFromFile = ev_file_get_mime_type(uri,FALSE,&err);
+    const gchar* mimeFromFile = ev_file_get_mime_type(uri,TRUE,&err);
 
     gchar* mimetypes[] = {"application/epub+zip","application/x-booki+zip"};
     int typecount = 2;

--- a/cut-n-paste/toolbar-editor/egg-toolbar-editor.c
+++ b/cut-n-paste/toolbar-editor/egg-toolbar-editor.c
@@ -149,6 +149,11 @@ egg_toolbar_editor_disconnect_model (EggToolbarEditor *t)
     {
       handler = priv->sig_handlers[i];
 
+#if GLIB_CHECK_VERSION(2,62,0)
+      if ((handler == 0) || !g_signal_handler_is_connected (model, handler))
+        continue;
+      g_clear_signal_handler (&handler, model);
+#else
       if (handler != 0)
         {
           if (g_signal_handler_is_connected (model, handler))
@@ -158,6 +163,7 @@ egg_toolbar_editor_disconnect_model (EggToolbarEditor *t)
 
           priv->sig_handlers[i] = 0;
         }
+#endif
     }
 }
 

--- a/cut-n-paste/zoom-control/ephy-zoom-control.c
+++ b/cut-n-paste/zoom-control/ephy-zoom-control.c
@@ -34,7 +34,7 @@ struct _EphyZoomControlPrivate
 	float zoom;
 	float min_zoom;
 	float max_zoom;
-	guint handler_id;
+	gulong handler_id;
 };
 
 enum

--- a/git.mk
+++ b/git.mk
@@ -367,6 +367,7 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk $(top_srcdir)/configure.a
 			"*~" \
 			".*.sw[nop]" \
 			".dirstamp" \
+			".vscode/" \
 		; do echo "/$$x"; done; \
 		for x in \
 			"*.$(OBJEXT)" \

--- a/libmisc/ev-page-action-widget.c
+++ b/libmisc/ev-page-action-widget.c
@@ -43,7 +43,7 @@ struct _EvPageActionWidget
 
 	GtkWidget *entry;
 	GtkWidget *label;
-	guint signal_id;
+	gulong signal_id;
 	GtkTreeModel *filter_model;
 	GtkTreeModel *model;
 };
@@ -202,11 +202,16 @@ ev_page_action_widget_document_changed_cb (EvDocumentModel    *model,
 		g_object_unref (action_widget->document);
 	action_widget->document = document;
 
+#if GLIB_CHECK_VERSION(2,62,0)
+	g_clear_signal_handler (&action_widget->signal_id,
+	                        action_widget->doc_model);
+#else
 	if (action_widget->signal_id > 0) {
 		g_signal_handler_disconnect (action_widget->doc_model,
 					     action_widget->signal_id);
 		action_widget->signal_id = 0;
 	}
+#endif
 	action_widget->signal_id =
 		g_signal_connect_object (action_widget->doc_model,
 					 "page-changed",
@@ -240,6 +245,13 @@ ev_page_action_widget_finalize (GObject *object)
 	EvPageActionWidget *action_widget = EV_PAGE_ACTION_WIDGET (object);
 
 	if (action_widget->doc_model != NULL) {
+#if GLIB_CHECK_VERSION(2,62,0)
+		if ((action_widget->signal_id != 0) &&
+		    (g_signal_handler_is_connected (action_widget->doc_model,
+		                                    action_widget->signal_id)))
+			g_clear_signal_handler (&action_widget->signal_id,
+			                        action_widget->doc_model);
+#else
 		if (action_widget->signal_id > 0) {
 			if (g_signal_handler_is_connected(action_widget->doc_model,
 							  action_widget->signal_id))
@@ -247,6 +259,7 @@ ev_page_action_widget_finalize (GObject *object)
 							     action_widget->signal_id);
 			action_widget->signal_id = 0;
 		}
+#endif
 		g_object_remove_weak_pointer (G_OBJECT (action_widget->doc_model),
 					      (gpointer)&action_widget->doc_model);
 		action_widget->doc_model = NULL;

--- a/shell/ev-sidebar-annotations.c
+++ b/shell/ev-sidebar-annotations.c
@@ -56,7 +56,7 @@ struct _EvSidebarAnnotationsPrivate {
 	GtkWidget *annot_text_item;
 
 	EvJob *job;
-	guint selection_changed_id;
+	gulong selection_changed_id;
 };
 
 static void ev_sidebar_annotations_page_iface_init (EvSidebarPageInterface *iface);

--- a/shell/ev-sidebar-links.c
+++ b/shell/ev-sidebar-links.c
@@ -39,9 +39,9 @@ struct _EvSidebarLinksPrivate {
 	GtkWidget *tree_view;
 
 	/* Keep these ids around for blocking */
-	guint selection_id;
-	guint page_changed_id;
-	guint row_activated_id;
+	gulong selection_id;
+	gulong page_changed_id;
+	gulong row_activated_id;
 
 	EvJob *job;
 	GtkTreeModel *model;
@@ -643,7 +643,7 @@ job_finished_callback (EvJobLinks     *job,
 	selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (priv->tree_view));
 	gtk_tree_selection_set_mode (selection, GTK_SELECTION_SINGLE);
 
-	if (priv->selection_id <= 0) {
+	if (priv->selection_id == 0) {
 		priv->selection_id =
 			g_signal_connect (selection, "changed",
 					  G_CALLBACK (selection_changed_callback),
@@ -653,7 +653,7 @@ job_finished_callback (EvJobLinks     *job,
 		g_signal_connect_swapped (priv->doc_model, "page-changed",
 					  G_CALLBACK (update_page_callback),
 					  sidebar_links);
-	if (priv->row_activated_id <= 0) {
+	if (priv->row_activated_id == 0) {
 		priv->row_activated_id =
 			g_signal_connect (priv->tree_view, "row-activated",
 					  G_CALLBACK (row_activated_callback),


### PR DESCRIPTION
Atril was doing a "deep" (the first 1024 bytes) MIME type guessing and this didn't work with some EPUB files.

Aside from the fact that GLib seems to be able to do a better job analyzing the file's URI on its own (are there any contraindications to this?), I preferred to simply do away with the deep check, since there's another MIME type check involved with EPUBs that executes before this one, one that checks for the presence of WebKit, and that one trusts the system's MIME type database (which in my case is based on the file's extension.)

Oh, and I have also added the VS Code config dir to the .gitignore make target because that's what I use. I hope I've done it the right way; I've been a programmer for a long time, but I'm VERY new w.r.t. creating pull requests and collaborating on GitHub (or in general), and I haven't touched C since before I turned pro (that's more that two decades ago.)