### PR TITLE
Fix runtime warning: assertion 'EV_IS_VIEW (view)' failed

### DIFF
--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -6116,6 +6116,9 @@ ev_window_cmd_view_toggle_caret_navigation (GtkAction *action,
 	GtkWidget *hbox;
 	gboolean   enabled;
 
+	if (window->priv->view == NULL)
+		return;
+
 	/* Don't ask for user confirmation to turn the caret navigation off when it is active,
 	 * or to turn it on when the confirmation dialog is not to be shown per settings */
 	enabled = ev_view_is_caret_navigation_enabled (EV_VIEW (window->priv->view));


### PR DESCRIPTION
Test: open an epub file ([epub30-spec.epub](https://github.com/IDPF/epub3-samples/releases/download/20170606/epub30-spec.epub)), next check ~/.xsession-errors log
```
$ cat ~/.xsession-errors
(atril:1841): GLib-GObject-WARNING **: 20:24:14.659: invalid unclassed pointer in cast to 'EvView'

(atril:1841): AtrilView-CRITICAL **: 20:24:14.659: ev_view_is_caret_navigation_enabled: assertion 'EV_IS_VIEW (view)' failed

````