### PR TITLE
Fix build with libxml2 2.12

### DIFF
--- a/cut-n-paste/toolbar-editor/egg-toolbars-model.c
+++ b/cut-n-paste/toolbar-editor/egg-toolbars-model.c
@@ -27,7 +27,9 @@
 
 #include <unistd.h>
 #include <string.h>
+#include <libxml/parser.h>
 #include <libxml/tree.h>
+#include <libxml/xmlsave.h>
 #include <gdk/gdk.h>
 
 static void egg_toolbars_model_finalize   (GObject               *object);


### PR DESCRIPTION
libxml 2.12.0 reorganized headers, resulting in xmlParseFile and xmlIndentTreeOutput no longer being in scope.
Let’s add the proper includes containing the symbols.
