### PR TITLE
epub: Avoid crash when index list has extraneous entry

### DIFF
--- a/backend/epub/epub-document.c
+++ b/backend/epub/epub-document.c
@@ -1044,7 +1044,7 @@ setup_document_content_list(const gchar* content_uri, GError** error,gchar *docu
         }
         if ( xmlStrcmp(itemrefptr->name,(xmlChar*)"itemref") == 0)
         {
-            contentListNode *newnode = g_malloc0(sizeof(newnode));
+            contentListNode *newnode = g_malloc0(sizeof(*newnode));
             newnode->key = (gchar*)xml_get_data_from_node(itemrefptr,XML_ATTRIBUTE,(xmlChar*)"idref");
             if ( newnode->key == NULL )
             {
@@ -1626,7 +1626,7 @@ page_set_function(linknode *Link, GList *contentList)
     contentListNode *pagedata;
 
     guint flag=0;
-    while (!flag) {
+    while (!flag && listiter) {
         pagedata = listiter->data;
         if (link_present_on_page(Link->pagelink, pagedata->value)) {
             flag=1;


### PR DESCRIPTION
This commit also fixes an incorrect `sizeof` call detected by AddressSanitizer.

Closes #599


### Testing
- Note: My testing occurred against the 1.26 branch
- I verified the EPUB from #599 can now be opened with Atril
- I verified that AddressSanitizer did not report any memory issues when loading the EPUB