### PR TITLE
Add configure and meson options to replace mate functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -120,7 +120,7 @@ PKG_CHECK_MODULES(BACKEND, cairo >= $CAIRO_REQUIRED gtk+-3.0 >= $GTK_REQUIRED)
 PKG_CHECK_MODULES(FRONTEND_CORE, gtk+-3.0 >= $GTK_REQUIRED gthread-2.0 gio-2.0 >= $GLIB_REQUIRED)
 PKG_CHECK_MODULES(GMODULE, gmodule-2.0 >= $GLIB_REQUIRED)
 
-PKG_CHECK_MODULES([SHELL_CORE],[libxml-2.0 >= $LIBXML_REQUIRED gtk+-3.0 >= $GTK_REQUIRED gio-2.0 >= $GLIB_REQUIRED gthread-2.0 x11 mate-desktop-2.0 >= $MATE_DESKTOP_REQUIRED])
+PKG_CHECK_MODULES([SHELL_CORE],[libxml-2.0 >= $LIBXML_REQUIRED gtk+-3.0 >= $GTK_REQUIRED gio-2.0 >= $GLIB_REQUIRED gthread-2.0 x11])
 
 AC_SUBST(GLIB_CFLAGS)
 AC_SUBST(GLIB_LIBS)
@@ -219,6 +219,25 @@ if test "$with_keyring" = "yes"; then
         PKG_CHECK_MODULES(LIBSECRET, libsecret-1 >= $LIBSECRET_REQUIRED)
         AC_DEFINE([WITH_KEYRING],[1],[Define if KEYRING support is enabled])
 fi
+
+# ****
+# MATE
+# ****
+AC_ARG_ENABLE([mate],
+  [AS_HELP_STRING([--disable-mate], [Disable functions from mate])],
+  [],
+  [enable_mate=yes])
+
+if test "$enable_mate" = "yes"; then
+  AC_DEFINE([ENABLE_MATE],[1],[Define if MATE functions are enabled])
+
+   PKG_CHECK_MODULES([MATE], [mate-desktop-2.0 >= $MATE_DESKTOP_REQUIRE],[found_mate=yes],[found_mate=no])
+  if test "x$found_mate" = "xno" ; then
+    AC_MSG_ERROR([*** mate-desktop not found ***])
+  fi
+fi
+
+AM_CONDITIONAL([ENABLE_MATE], [test "$enable_mate" = "yes"])
 
 # ****
 # DBUS
@@ -783,6 +802,7 @@ Configure summary:
     GTK+ Unix Print.....:    $with_gtk_unix_print
     Keyring Support.....:    $with_keyring
     DBUS Support........:    $enable_dbus
+    Mate Functions......:    $enable_mate
     Caja Plugin.........:    $enable_caja
     Thumbnailer.........:    $enable_thumbnailer
     Previewer...........:    $enable_previewer

--- a/configure.ac
+++ b/configure.ac
@@ -231,7 +231,7 @@ AC_ARG_ENABLE([mate],
 if test "$enable_mate" = "yes"; then
   AC_DEFINE([ENABLE_MATE],[1],[Define if MATE functions are enabled])
 
-   PKG_CHECK_MODULES([MATE], [mate-desktop-2.0 >= $MATE_DESKTOP_REQUIRE],[found_mate=yes],[found_mate=no])
+   PKG_CHECK_MODULES([MATE], [mate-desktop-2.0 >= $MATE_DESKTOP_REQUIRED],[found_mate=yes],[found_mate=no])
   if test "x$found_mate" = "xno" ; then
     AC_MSG_ERROR([*** mate-desktop not found ***])
   fi

--- a/meson.build
+++ b/meson.build
@@ -66,7 +66,12 @@ xml = dependency('libxml-2.0', version: '>= 2.5.0')
 zlib = dependency('zlib')
 libsecret = dependency('libsecret-1', version: '>= 0.5', required: get_option('keyring'))
 gtk_unix_print = dependency('gtk+-unix-print-3.0', version: '>= ' + gtk_version, required: get_option('gtk_unix_print'))
-mate_desktop = dependency('mate-desktop-2.0', version: '>= 1.27.1')
+
+# Mate functions
+if get_option('mate')
+  mate_desktop = dependency('mate-desktop-2.0', version: '>= 1.27.1')
+  atril_conf.set10('ENABLE_MATE', true)
+endif
 
 # Backend configuration
 enabled_backend_names = []
@@ -347,6 +352,7 @@ summary = [
   'libexecdir = @0@'.format(libexecdir),
   'desktopdir = @0@'.format(desktopdir),
   'schema_dir = @0@'.format(schema_dir),
+  'ENABLE_MATE = @0@'.format(get_option('mate')),
   'ENABLE_DBUS = @0@'.format(get_option('enable_dbus')),
   'MathJax directory = @0@'.format(mathjax_directory),
   '',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -63,6 +63,11 @@ option('mathjax-directory',
     value: '',
     description: 'Path to the system mathjax installation.'
 )
+option('mate',
+    type: 'boolean',
+    value: true,
+    description: 'Build with mate functions'
+)
 option('previewer',
     type: 'boolean',
     value: true,

--- a/shell/ev-navigation-action.c
+++ b/shell/ev-navigation-action.c
@@ -26,7 +26,9 @@
 #include "ev-navigation-action.h"
 #include "ev-navigation-action-widget.h"
 
+#ifdef ENABLE_MATE
 #include <libmate-desktop/mate-image-menu-item.h>
+#endif
 
 enum
 {
@@ -101,7 +103,11 @@ new_history_menu_item (EvNavigationAction *action,
 	const char *title;
 
 	title = ev_link_get_title (link);
+#ifdef ENABLE_MATE
 	item = mate_image_menu_item_new_with_label (title);
+#else
+	item = gtk_menu_item_new_with_label (title);
+#endif
 	label = GTK_LABEL (gtk_bin_get_child (GTK_BIN (item)));
 	gtk_label_set_use_markup (label, TRUE);
 	g_object_set_data (G_OBJECT (item), "index",

--- a/shell/ev-sidebar-links.c
+++ b/shell/ev-sidebar-links.c
@@ -29,7 +29,9 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
+#ifdef ENABLE_MATE
 #include <libmate-desktop/mate-image-menu-item.h>
+#endif
 
 #include "ev-document-links.h"
 #include "ev-job-scheduler.h"
@@ -337,9 +339,17 @@ build_popup_menu (EvSidebarLinks *sidebar)
 	GtkWidget *item;
 
 	menu = gtk_menu_new ();
+#ifdef ENABLE_MATE
 	item = mate_image_menu_item_new_with_label ("Print…");
+#else
+	item = gtk_menu_item_new_with_label ("Print…");
+#endif
 	image = gtk_image_new_from_icon_name ("gtk-print", GTK_ICON_SIZE_MENU);
+#ifdef ENABLE_MATE
 	mate_image_menu_item_set_image (MATE_IMAGE_MENU_ITEM (item), image);
+#else
+	gtk_image_menu_item_set_image (GTK_IMAGE_MENU_ITEM (item), image);
+#endif
 	gtk_widget_show (item);
 	gtk_menu_shell_append (GTK_MENU_SHELL (menu), item);
 	g_signal_connect (item, "activate",

--- a/shell/ev-sidebar.c
+++ b/shell/ev-sidebar.c
@@ -31,7 +31,9 @@
 #include <gtk/gtk.h>
 #include <gdk/gdkkeysyms.h>
 
+#ifdef ENABLE_MATE
 #include <libmate-desktop/mate-image-menu-item.h>
+#endif
 
 #include "ev-sidebar.h"
 #include "ev-sidebar-page.h"
@@ -429,7 +431,11 @@ ev_sidebar_add_page (EvSidebar   *ev_sidebar,
 	index = gtk_notebook_append_page (GTK_NOTEBOOK (ev_sidebar->priv->notebook),
 					  main_widget, NULL);
 
+#ifdef ENABLE_MATE
 	menu_item = mate_image_menu_item_new_with_label (title);
+#else
+	menu_item = gtk_menu_item_new_with_label (title);
+#endif
 	g_signal_connect (menu_item, "activate",
 			  G_CALLBACK (ev_sidebar_menu_item_activate_cb),
 			  ev_sidebar);

--- a/shell/meson.build
+++ b/shell/meson.build
@@ -100,11 +100,14 @@ atril_deps = [
     gtk,
     libsecret,
     math,
-    mate_desktop,
     mate_submodules_dep,
     libtoolbareditor_dep,
     libevproperties_dep
 ]
+
+if get_option('mate')
+    atril_deps += mate_desktop
+endif
 
 if get_option('enable_dbus')
     dbus_generated = gnome.gdbus_codegen(


### PR DESCRIPTION
Allows building `atril` without mate-desktop.
Both configure and meson are modified.
This was only tested on a system without mate-desktop, so it needs reviewing and more testing.
The GTK functions used to replace mate's ones generate compilation warnings because they're deprecated.