### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Atril Requirements to Run Tests
 
 Atril Compilation
 ==================================================
+* git clone https://github.com/mate-desktop/atril
 * git submodule init
 * git submodule update --remote --recursive
+* apt build-dep -y atril 
 * ./autogen.sh
 * make


### PR DESCRIPTION
makes it easier to compile by adding apt build-dep to install all necessary dependencies atril needs.