### PR TITLE
Fixed gir install path variables

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -339,38 +339,7 @@ AC_SUBST(PREVIEWER_LIBS)
 # GIR
 # ***
 
-AC_MSG_CHECKING([whether GObject introspection is requested])
-AC_ARG_ENABLE([introspection],
-    AS_HELP_STRING([--enable-introspection],
-                   [Enable GObject introspection]),
-    [enable_introspection=$enableval],
-    [enable_introspection=no])
-AC_MSG_RESULT([$enable_introspection])
-
-G_IR_SCANNER=
-G_IR_COMPILER=
-G_IR_GENERATE=
-GIRDIR=
-GIRTYPELIBDIR=
-
-if test "$enable_introspection" = "yes"; then
-  GOBJECT_INTROSPECTION_REQUIRED=0.6
-  PKG_CHECK_MODULES([GOBJECT_INTROSPECTION],[gobject-introspection-1.0 >= $GOBJECT_INTROSPECTION_REQUIRED])
-
-  G_IR_SCANNER="$($PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0)"
-  G_IR_COMPILER="$($PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0)"
-  G_IR_GENERATE="$($PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0)"
-  GIRDIR="$($PKG_CONFIG --variable=girdir gobject-introspection-1.0)"
-  GIRTYPELIBDIR="$($PKG_CONFIG --variable=typelibdir gobject-introspection-1.0)"
-fi
-
-AC_SUBST([G_IR_SCANNER])
-AC_SUBST([G_IR_COMPILER])
-AC_SUBST([G_IR_GENERATE])
-AC_SUBST([GIRDIR])
-AC_SUBST([GIRTYPELIBDIR])
-
-AM_CONDITIONAL([ENABLE_INTROSPECTION],[test "$enable_introspection" = "yes"])
+GOBJECT_INTROSPECTION_CHECK([0.6])
 
 dnl ================== libsynctex ===========================================
 AC_ARG_ENABLE([synctex],

--- a/libdocument/Makefile.am
+++ b/libdocument/Makefile.am
@@ -156,46 +156,34 @@ EXTRA_DIST = \
 
 # GObject Introspection
 
-if ENABLE_INTROSPECTION
+-include $(INTROSPECTION_MAKEFILE)
+INTROSPECTION_GIRS =
+INTROSPECTION_SCANNER_ENV = PKG_CONFIG_PATH=$(top_builddir):$$PKG_CONFIG_PATH
+INTROSPECTION_SCANNER_ARGS = -v --strip-prefix=Ev
+INTROSPECTION_COMPILER_ARGS = --includedir=$(srcdir)
 
-AtrilDocument-$(EV_API_VERSION).gir: libatrildocument.la Makefile $(INST_H_FILES) $(filter %.c,$(libatrildocument_la_SOURCES))
-	$(AM_V_GEN) PKG_CONFIG_PATH=$(top_builddir):$$PKG_CONFIG_PATH \
-	$(G_IR_SCANNER) -v --namespace AtrilDocument \
-	--strip-prefix=Ev \
-	--nsversion=$(EV_API_VERSION) \
-	--include=GLib-2.0 \
-	--include=Gio-2.0 \
-	--include=Gdk-3.0 \
-	--include=GdkPixbuf-2.0 \
-	--include=Gtk-3.0 \
-	--library=libatrildocument.la \
-	--libtool="$(LIBTOOL)" \
-	--output $@ \
-	--pkg atril-document-$(EV_API_VERSION) \
-	-I$(top_srcdir) \
-	-I$(top_builddir) \
-	-I$(srcdir) \
-	-I$(builddir) \
-	-DATRIL_COMPILATION \
-	$(filter %.h,$^) \
-	$(filter %.c,$^)
+if HAVE_INTROSPECTION
 
-girdir = $(datadir)/gir-1.0
-gir_DATA = AtrilDocument-$(EV_API_VERSION).gir
+AtrilDocument-$(EV_API_VERSION).gir: libatrildocument.la
+AtrilDocument_@EV_API_VERSION_U@_gir_NAMESPACE = AtrilDocument
+AtrilDocument_@EV_API_VERSION_U@_gir_VERSION = $(EV_API_VERSION)
+AtrilDocument_@EV_API_VERSION_U@_gir_INCLUDES = GLib-2.0 Gio-2.0 Gdk-3.0 GdkPixbuf-2.0 Gtk-3.0
+AtrilDocument_@EV_API_VERSION_U@_gir_LIBS = libatrildocument.la
+AtrilDocument_@EV_API_VERSION_U@_gir_PACKAGES = atril-document-$(EV_API_VERSION)
+AtrilDocument_@EV_API_VERSION_U@_gir_CFLAGS = -I$(top_srcdir) -I$(top_builddir) \
+	-I$(srcdir) -I$(builddir) -DATRIL_COMPILATION
+AtrilDocument_@EV_API_VERSION_U@_gir_FILES = $(INST_H_FILES) $(filter %.c,$(libatrildocument_la_SOURCES))
+INTROSPECTION_GIRS += AtrilDocument-$(EV_API_VERSION).gir
 
-typelibsdir = $(libdir)/girepository-1.0
-typelibs_DATA = AtrilDocument-$(EV_API_VERSION).typelib
+girdir = $(INTROSPECTION_GIRDIR)
+gir_DATA = $(INTROSPECTION_GIRS)
+
+typelibdir = $(INTROSPECTION_TYPELIBDIR)
+typelib_DATA = $(INTROSPECTION_GIRS:.gir=.typelib)
 
 EXTRA_DIST += $(gir_DATA)
-CLEANFILES += $(gir_DATA) $(typelibs_DATA)
+CLEANFILES += $(gir_DATA) $(typelib_DATA)
 
-%.typelib: %.gir
-	$(AM_V_GEN) LD_LIBRARY_PATH=$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}. $(G_IR_COMPILER) \
-	--includedir=$(srcdir) \
-	--includedir=. \
-	$(G_IR_COMPILER_OPTS) \
-	$< -o $@
-
-endif # ENABLE_INTROSPECTION
+endif # HAVE_INTROSPECTION
 
 -include $(top_srcdir)/git.mk

--- a/libdocument/Makefile.am
+++ b/libdocument/Makefile.am
@@ -180,10 +180,10 @@ AtrilDocument-$(EV_API_VERSION).gir: libatrildocument.la Makefile $(INST_H_FILES
 	$(filter %.h,$^) \
 	$(filter %.c,$^)
 
-girdir = $(GIRDIR)
+girdir = $(datadir)/gir-1.0
 gir_DATA = AtrilDocument-$(EV_API_VERSION).gir
 
-typelibsdir = $(GIRTYPELIBDIR)
+typelibsdir = $(libdir)/girepository-1.0
 typelibs_DATA = AtrilDocument-$(EV_API_VERSION).typelib
 
 EXTRA_DIST += $(gir_DATA)

--- a/libview/Makefile.am
+++ b/libview/Makefile.am
@@ -126,49 +126,35 @@ EXTRA_DIST = \
 
 # GObject Introspection
 
-if ENABLE_INTROSPECTION
+-include $(INTROSPECTION_MAKEFILE)
+INTROSPECTION_GIRS =
+INTROSPECTION_SCANNER_ENV = PKG_CONFIG_PATH=$(top_builddir):$$PKG_CONFIG_PATH
+INTROSPECTION_SCANNER_ARGS = -v --add-include-path=$(top_builddir)/libdocument --strip-prefix=Ev
+INTROSPECTION_COMPILER_ARGS = --includedir=$(srcdir) --includedir=$(top_builddir)/libdocument
 
-AtrilView-$(EV_API_VERSION).gir: libatrilview.la Makefile $(INST_H_FILES) $(filter %.c,$(libatrilview_la_SOURCES))
-	$(AM_V_GEN) PKG_CONFIG_PATH=$(top_builddir):$$PKG_CONFIG_PATH \
-	$(G_IR_SCANNER) -v --namespace AtrilView \
-	--add-include-path=$(top_builddir)/libdocument \
-	--strip-prefix=Ev \
-	--nsversion=$(EV_API_VERSION) \
-	--include=GLib-2.0 \
-	--include=GObject-2.0 \
-	--include=Gio-2.0 \
-	--include=Gdk-3.0 \
-	--include=GdkPixbuf-2.0 \
-	--include=Gtk-3.0 \
-	--include=AtrilDocument-$(EV_API_VERSION) \
-	--library=libatrilview.la \
-	--libtool="$(LIBTOOL)" \
-	--output $@ \
-	--pkg atril-document-$(EV_API_VERSION) \
-	--pkg atril-view-$(EV_API_VERSION) \
-	-L$(top_builddir)/libdocument/ \
-	-I$(top_srcdir) \
-	-I$(top_builddir) \
-	-DATRIL_COMPILATION \
-	$(filter %.h,$^) \
-	$(filter %.c,$^)
+if HAVE_INTROSPECTION
 
-girdir = $(datadir)/gir-1.0
-gir_DATA = AtrilView-$(EV_API_VERSION).gir
+AtrilView-$(EV_API_VERSION).gir: libatrilview.la
+AtrilView_@EV_API_VERSION_U@_gir_NAMESPACE = AtrilView
+AtrilView_@EV_API_VERSION_U@_gir_VERSION = $(EV_API_VERSION)
+AtrilView_@EV_API_VERSION_U@_gir_INCLUDES = GLib-2.0 GObject-2.0 Gio-2.0 Gdk-3.0 \
+	GdkPixbuf-2.0 Gtk-3.0 AtrilDocument-$(EV_API_VERSION)
+AtrilView_@EV_API_VERSION_U@_gir_LIBS = libatrilview.la
+AtrilView_@EV_API_VERSION_U@_gir_PACKAGES = atril-document-$(EV_API_VERSION) atril-view-$(EV_API_VERSION)
+AtrilView_@EV_API_VERSION_U@_gir_CFLAGS = -I$(top_srcdir) -I$(top_builddir) -DATRIL_COMPILATION
+AtrilView_@EV_API_VERSION_U@_gir_LDFLAGS = -L$(top_builddir)/libdocument/
+AtrilView_@EV_API_VERSION_U@_gir_FILES = $(INST_H_FILES) $(filter %.c,$(libatrilview_la_SOURCES))
+INTROSPECTION_GIRS += AtrilView-$(EV_API_VERSION).gir
 
-typelibsdir = $(libdir)/girepository-1.0
-typelibs_DATA = AtrilView-$(EV_API_VERSION).typelib
+girdir = $(INTROSPECTION_GIRDIR)
+gir_DATA = $(INTROSPECTION_GIRS)
+
+typelibdir = $(INTROSPECTION_TYPELIBDIR)
+typelib_DATA = $(INTROSPECTION_GIRS:.gir=.typelib)
 
 EXTRA_DIST += $(gir_DATA)
-CLEANFILES += $(gir_DATA) $(typelibs_DATA)
+CLEANFILES += $(gir_DATA) $(typelib_DATA)
 
-%.typelib: %.gir
-	$(AM_V_GEN) LD_LIBRARY_PATH=$${LD_LIBRARY_PATH:+$$LD_LIBRARY_PATH:}. $(G_IR_COMPILER) \
-	--includedir=$(srcdir) \
-	--includedir=$(top_builddir)/libdocument \
-	$(G_IR_COMPILER_OPTS) \
-	$< -o $@
-
-endif # ENABLE_INTROSPECTION
+endif # HAVE_INTROSPECTION
 
 -include $(top_srcdir)/git.mk

--- a/libview/Makefile.am
+++ b/libview/Makefile.am
@@ -153,10 +153,10 @@ AtrilView-$(EV_API_VERSION).gir: libatrilview.la Makefile $(INST_H_FILES) $(filt
 	$(filter %.h,$^) \
 	$(filter %.c,$^)
 
-girdir = $(GIRDIR)
+girdir = $(datadir)/gir-1.0
 gir_DATA = AtrilView-$(EV_API_VERSION).gir
 
-typelibsdir = $(GIRTYPELIBDIR)
+typelibsdir = $(libdir)/girepository-1.0
 typelibs_DATA = AtrilView-$(EV_API_VERSION).typelib
 
 EXTRA_DIST += $(gir_DATA)


### PR DESCRIPTION
Changed girdir and typelibsdir to depend upon configured prefix settings, similarly to other MATE projects.
Fixes #647.