### PR TITLE
Fix meson pkg-config compatibility with configure

### DIFF
--- a/libdocument/meson.build
+++ b/libdocument/meson.build
@@ -124,7 +124,7 @@ libdocument_deps = [
 ]
 
 libdocument = library(
-    'document',
+    'atrildocument',
     libdocument_private_headers + libdocument_sources,
     dependencies: libdocument_deps,
     include_directories: include_root,

--- a/libview/meson.build
+++ b/libview/meson.build
@@ -85,7 +85,7 @@ if get_option('epub')
 endif
 
 libview = library(
-    'view',
+    'atrilview',
     libview_sources + libview_private_headers + libdoc_enums + libview_marshal,
     include_directories: include_dirs,
     dependencies: libview_deps,

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,7 @@ major_version = version_list[0]
 minor_version = version_list[1]
 micro_version = version_list[2]
 
-api_version = '1.5'
+api_version = '1.5.0'
 binary_version = '3.0.0'
 binary_major_version = binary_version.split('.')[0]
 


### PR DESCRIPTION
pkg-config input files set -latrilview etc. but the library outputs created were libview.so, so any project that used pkg-config for libatril was broken, not to mention that the file itself also got renamed from its previous value and pkg-config wouldn't find it anymore. Now it is hopefully more consistent with the output from autotools builds. (See #663.)