### PR TITLE
Fix zoom limits

### DIFF
--- a/data/org.mate.Atril.gschema.xml
+++ b/data/org.mate.Atril.gschema.xml
@@ -26,7 +26,7 @@
       <summary>The URI of the directory last used to save a picture.</summary>
     </key>
     <key name="page-cache-size" type="u">
-      <default>50</default>
+      <default>500</default>
       <summary>Page cache size in MiB</summary>
       <description>The maximum size that will be used to cache rendered pages, limits maximum zoom level.</description>
     </key>

--- a/libview/ev-pixbuf-cache.c
+++ b/libview/ev-pixbuf-cache.c
@@ -430,11 +430,14 @@ ev_pixbuf_cache_get_page_size (EvPixbufCache *pixbuf_cache,
 			       gint           rotation)
 {
 	gint width, height;
+	gint device_scale;
 
+	device_scale = get_device_scale (pixbuf_cache);
 	_get_page_size_for_scale_and_rotation (pixbuf_cache->document,
 					       page_index, scale, rotation,
 					       &width, &height);
-	return height * cairo_format_stride_for_width (CAIRO_FORMAT_RGB24, width);
+	return (height * device_scale) *
+		cairo_format_stride_for_width (CAIRO_FORMAT_RGB24, width * device_scale);
 }
 
 static gint

--- a/libview/ev-view-private.h
+++ b/libview/ev-view-private.h
@@ -165,6 +165,8 @@ struct _EvView {
 	gint spacing;
 
 	gboolean loading;
+	gboolean can_zoom_in;
+	gboolean can_zoom_out;
 	gboolean continuous;
 	gboolean dual_even_left;
 	gboolean fullscreen;

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -229,6 +229,8 @@ static double   zoom_for_size_automatic                      (GdkScreen *screen,
 							      gdouble    doc_height,
 							      int        target_width,
 							      int        target_height);
+static gboolean ev_view_can_zoom                             (EvView *view,
+							      gdouble factor);
 static void     ev_view_zoom_for_size                        (EvView *view,
 							      int     width,
 							      int     height);
@@ -3819,8 +3821,7 @@ ev_view_scroll_event (GtkWidget *widget, GdkEventScroll *event)
 			gdouble delta = event->delta_x + event->delta_y;
 			gdouble factor = pow (delta < 0 ? ZOOM_IN_FACTOR : ZOOM_OUT_FACTOR, fabs (delta));
 
-			if ((factor < 1.0 && ev_view_can_zoom_out (view)) ||
-			    (factor >= 1.0 && ev_view_can_zoom_in (view)))
+			if (ev_view_can_zoom (view, factor))
 				ev_view_zoom (view, factor);
 		}
 			break;
@@ -6472,8 +6473,7 @@ zoom_gesture_scale_changed_cb (GtkGestureZoom *gesture,
 
 	gtk_gesture_get_bounding_box_center (GTK_GESTURE (gesture), &view->zoom_center_x, &view->zoom_center_y);
 
-	if ((factor < 1.0 && ev_view_can_zoom_out (view)) ||
-	    (factor >= 1.0 && ev_view_can_zoom_in (view)))
+	if (ev_view_can_zoom (view, factor))
 		ev_view_zoom (view, factor);
 }
 
@@ -6906,8 +6906,8 @@ update_can_zoom (EvView *view)
 	min_scale = ev_document_model_get_min_scale (view->model);
 	max_scale = ev_document_model_get_max_scale (view->model);
 
-	can_zoom_in = (view->scale * ZOOM_IN_FACTOR) <= max_scale;
-	can_zoom_out = (view->scale * ZOOM_OUT_FACTOR) > min_scale;
+	can_zoom_in = view->scale <= max_scale;
+	can_zoom_out = view->scale > min_scale;
 
 	if (can_zoom_in != view->can_zoom_in) {
 		view->can_zoom_in = can_zoom_in;
@@ -7098,6 +7098,19 @@ ev_view_reload (EvView *view)
 }
 
 /*** Zoom and sizing mode ***/
+
+static gboolean
+ev_view_can_zoom (EvView *view, gdouble factor)
+{
+	if (factor == 1.0)
+		return TRUE;
+
+	else if (factor < 1.0) {
+		return ev_view_can_zoom_out (view);
+	} else {
+		return ev_view_can_zoom_in (view);
+	}
+}
 
 gboolean
 ev_view_can_zoom_in (EvView *view)

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -73,7 +73,9 @@ enum {
 	PROP_HADJUSTMENT,
 	PROP_VADJUSTMENT,
 	PROP_HSCROLL_POLICY,
-	PROP_VSCROLL_POLICY
+	PROP_VSCROLL_POLICY,
+	PROP_CAN_ZOOM_IN,
+	PROP_CAN_ZOOM_OUT
 };
 
 static guint signals[N_SIGNALS] = { 0 };
@@ -5988,6 +5990,12 @@ ev_view_get_property (GObject     *object,
 	case PROP_IS_LOADING:
 		g_value_set_boolean (value, view->loading);
 		break;
+	case PROP_CAN_ZOOM_IN:
+		g_value_set_boolean (value, view->can_zoom_in);
+		break;
+	case PROP_CAN_ZOOM_OUT:
+		g_value_set_boolean (value, view->can_zoom_out);
+		break;
 	case PROP_HADJUSTMENT:
 		g_value_set_object (value, view->hadjustment);
 		break;
@@ -6260,6 +6268,23 @@ ev_view_class_init (EvViewClass *class)
 							       "Is Loading",
 							       "Whether the view is loading",
 							       FALSE,
+							       G_PARAM_READABLE |
+							       G_PARAM_STATIC_STRINGS));
+
+	g_object_class_install_property (object_class,
+					 PROP_CAN_ZOOM_IN,
+					 g_param_spec_boolean ("can-zoom-in",
+							       "Can Zoom In",
+							       "Whether the view can be zoomed in further",
+							       TRUE,
+							       G_PARAM_READABLE |
+							       G_PARAM_STATIC_STRINGS));
+	g_object_class_install_property (object_class,
+					 PROP_CAN_ZOOM_OUT,
+					 g_param_spec_boolean ("can-zoom-out",
+							       "Can Zoom Out",
+							       "Whether the view can be zoomed out further",
+							       TRUE,
 							       G_PARAM_READABLE |
 							       G_PARAM_STATIC_STRINGS));
 
@@ -6871,6 +6896,31 @@ ev_view_sizing_mode_changed_cb (EvDocumentModel *model,
 }
 
 static void
+update_can_zoom (EvView *view)
+{
+	gdouble min_scale;
+	gdouble max_scale;
+	gboolean can_zoom_in;
+	gboolean can_zoom_out;
+
+	min_scale = ev_document_model_get_min_scale (view->model);
+	max_scale = ev_document_model_get_max_scale (view->model);
+
+	can_zoom_in = (view->scale * ZOOM_IN_FACTOR) <= max_scale;
+	can_zoom_out = (view->scale * ZOOM_OUT_FACTOR) > min_scale;
+
+	if (can_zoom_in != view->can_zoom_in) {
+		view->can_zoom_in = can_zoom_in;
+		g_object_notify (G_OBJECT (view), "can-zoom-in");
+	}
+
+	if (can_zoom_out != view->can_zoom_out) {
+		view->can_zoom_out = can_zoom_out;
+		g_object_notify (G_OBJECT (view), "can-zoom-out");
+	}
+}
+
+static void
 ev_view_page_layout_changed_cb (EvDocumentModel *model,
 				GParamSpec      *pspec,
 				EvView          *view)
@@ -6903,6 +6953,24 @@ ev_view_scale_changed_cb (EvDocumentModel *model,
 	view->pending_resize = TRUE;
 	if (view->sizing_mode == EV_SIZING_FREE)
 		gtk_widget_queue_resize (GTK_WIDGET (view));
+
+	update_can_zoom (view);
+}
+
+static void
+ev_view_min_scale_changed_cb (EvDocumentModel *model,
+			      GParamSpec      *pspec,
+			      EvView          *view)
+{
+	update_can_zoom (view);
+}
+
+static void
+ev_view_max_scale_changed_cb (EvDocumentModel *model,
+			      GParamSpec      *pspec,
+			      EvView          *view)
+{
+	update_can_zoom (view);
 }
 
 static void
@@ -6986,6 +7054,12 @@ ev_view_set_model (EvView          *view,
 	g_signal_connect (view->model, "notify::scale",
 			  G_CALLBACK (ev_view_scale_changed_cb),
 			  view);
+	g_signal_connect (view->model, "notify::min-scale",
+			  G_CALLBACK (ev_view_min_scale_changed_cb),
+			  view);
+	g_signal_connect (view->model, "notify::max-scale",
+			  G_CALLBACK (ev_view_max_scale_changed_cb),
+			  view);
 	g_signal_connect (view->model, "notify::continuous",
 			  G_CALLBACK (ev_view_continuous_changed_cb),
 			  view);
@@ -7028,13 +7102,13 @@ ev_view_reload (EvView *view)
 gboolean
 ev_view_can_zoom_in (EvView *view)
 {
-	return view->scale * ZOOM_IN_FACTOR <= ev_document_model_get_max_scale (view->model);
+	return view->can_zoom_in;
 }
 
 gboolean
 ev_view_can_zoom_out (EvView *view)
 {
-	return view->scale * ZOOM_OUT_FACTOR >= ev_document_model_get_min_scale (view->model);
+	return view->can_zoom_out;
 }
 
 void

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -4670,10 +4670,8 @@ ev_window_update_max_min_scale (EvWindow *window)
 	gdouble    dpi;
 	GtkAction *action;
 	gdouble    min_width, min_height;
-	gdouble    width, height;
 	gdouble    max_scale;
 	guint      page_cache_mb;
-	gint       rotation = ev_document_model_get_rotation (window->priv->model);
 
 	if (!window->priv->document)
 		return;
@@ -4682,9 +4680,7 @@ ev_window_update_max_min_scale (EvWindow *window)
 	dpi = get_monitor_dpi (window) / 72.0;
 
 	ev_document_get_min_page_size (window->priv->document, &min_width, &min_height);
-	width = (rotation == 0 || rotation == 180) ? min_width : min_height;
-	height = (rotation == 0 || rotation == 180) ? min_height : min_width;
-	max_scale = sqrt ((page_cache_mb * 1024 * 1024) / (width * dpi * 4 * height * dpi));
+	max_scale = sqrt ((page_cache_mb * 1024 * 1024) / (min_width * dpi * 4 * min_height * dpi));
 
 	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->priv->action_group,

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -4690,7 +4690,7 @@ ev_window_update_max_min_scale (EvWindow *window)
 	action = gtk_action_group_get_action (window->priv->action_group,
 					      ZOOM_CONTROL_ACTION);
 	G_GNUC_END_IGNORE_DEPRECATIONS;
-	ephy_zoom_action_set_max_zoom_level (EPHY_ZOOM_ACTION (action), max_scale * dpi);
+	ephy_zoom_action_set_max_zoom_level (EPHY_ZOOM_ACTION (action), max_scale);
 
 	ev_document_model_set_min_scale (window->priv->model, MIN_SCALE * dpi);
 	ev_document_model_set_max_scale (window->priv->model, max_scale * dpi);

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -4664,12 +4664,21 @@ ev_window_setup_gtk_settings (EvWindow *window)
 	g_free (menubar_accel_accel);
 }
 
+/*
+ * Cairo image surfaces don't reliably work on
+ * images larger than 32767 in width or height.
+ * See https://gitlab.freedesktop.org/cairo/cairo/-/commit/9e45673e
+ */
+#define CAIRO_MAX_IMAGE_SIZE 32767
+
 static void
 ev_window_update_max_min_scale (EvWindow *window)
 {
 	gdouble    dpi;
+	gint       scale;
 	GtkAction *action;
 	gdouble    min_width, min_height;
+	gdouble    max_width, max_height;
 	gdouble    max_scale;
 	guint      page_cache_mb;
 
@@ -4678,9 +4687,15 @@ ev_window_update_max_min_scale (EvWindow *window)
 
 	page_cache_mb = g_settings_get_uint (window->priv->settings, GS_PAGE_CACHE_SIZE);
 	dpi = get_monitor_dpi (window) / 72.0;
+	scale = gtk_widget_get_scale_factor (GTK_WIDGET (window));
 
 	ev_document_get_min_page_size (window->priv->document, &min_width, &min_height);
 	max_scale = sqrt ((page_cache_mb * 1024 * 1024) / (min_width * dpi * 4 * min_height * dpi));
+
+	/* Cap zoom so rendered pages stay within cairo's pixel limit.
+	 * Use the largest page since any page could be rendered. */
+	ev_document_get_max_page_size (window->priv->document, &max_width, &max_height);
+	max_scale = MIN (max_scale, (gdouble)(CAIRO_MAX_IMAGE_SIZE - 1) / (MAX (max_width, max_height) * dpi * scale));
 
 	G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	action = gtk_action_group_get_action (window->priv->action_group,


### PR DESCRIPTION
Currently Atril limits zoom based on the page cache size, configured in gsettings `org.mate.Atril page-cache-size`. Default is 50MB, which prevents large images from zooming in properly. However, increasing that limit too high can crash Atril if you zoom an image to be larger than the surface renderer can handle.

This change backports a few fixes from Evince and adds zoom limit calculations so that the page cache size can be increased safely.

Fixes #575
