### PR TITLE
fix: do not clear PDF modification flags on save

### DIFF
--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -251,20 +251,14 @@ pdf_document_save (EvDocument  *document,
 	gboolean retval;
 	GError *poppler_error = NULL;
 
-	if (pdf_document->forms_modified || pdf_document->annots_modified) {
-		retval = poppler_document_save (pdf_document->document,
-						uri, &poppler_error);
-		if (retval) {
-			pdf_document->forms_modified = FALSE;
-			pdf_document->annots_modified = FALSE;
-		}
+	retval = poppler_document_save (pdf_document->document,
+					uri, &poppler_error);
+	if (retval) {
+		pdf_document->forms_modified = FALSE;
+		pdf_document->annots_modified = FALSE;
 	} else {
-		retval = poppler_document_save_a_copy (pdf_document->document,
-						       uri, &poppler_error);
-	}
-						       
-	if (! retval)
 		convert_error (poppler_error, error);
+	}
 
 	return retval;
 }


### PR DESCRIPTION
When using Save As, Atril clears the flags that indicate the PDF has been modified. Unfortunately, on the next save without modifying the document, Atril uses `poppler_document_save_a_copy()`, which does not keep user edits to the form. Thus, the user is led to believe what they are seeing on the screen is saved, only to close and re-open an empty document.

Since we are NOT reloading the original file the flags should not be cleared.

In fact even if we were to change the URI to the newly saved file as indicated in Save As, if the flags are unset then the next Save As invocation will get rid of user edits to the form, so I'm not sure why the flags were ever cleared to begin with.

Fixes #682