### PR TITLE
Add support for reading highlight annotations

### DIFF
--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -2686,6 +2686,9 @@ ev_annot_from_poppler_annot (PopplerAnnot *poppler_annot,
 				g_object_unref (poppler_attachment);
 		}
 			break;
+	        case POPPLER_ANNOT_HIGHLIGHT:
+			ev_annot = ev_annotation_text_markup_highlight_new (page);
+			break;
 	        case POPPLER_ANNOT_LINK:
 	        case POPPLER_ANNOT_WIDGET:
 			/* Ignore link and widgets annots since they are already handled */

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -2689,6 +2689,9 @@ ev_annot_from_poppler_annot (PopplerAnnot *poppler_annot,
 	        case POPPLER_ANNOT_HIGHLIGHT:
 			ev_annot = ev_annotation_text_markup_highlight_new (page);
 			break;
+	        case POPPLER_ANNOT_STRIKE_OUT:
+			ev_annot = ev_annotation_text_markup_strike_out_new (page);
+			break;
 	        case POPPLER_ANNOT_LINK:
 	        case POPPLER_ANNOT_WIDGET:
 			/* Ignore link and widgets annots since they are already handled */

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -2692,6 +2692,9 @@ ev_annot_from_poppler_annot (PopplerAnnot *poppler_annot,
 	        case POPPLER_ANNOT_STRIKE_OUT:
 			ev_annot = ev_annotation_text_markup_strike_out_new (page);
 			break;
+	        case POPPLER_ANNOT_UNDERLINE:
+			ev_annot = ev_annotation_text_markup_underline_new (page);
+			break;
 	        case POPPLER_ANNOT_LINK:
 	        case POPPLER_ANNOT_WIDGET:
 			/* Ignore link and widgets annots since they are already handled */

--- a/backend/pdf/ev-poppler.cc
+++ b/backend/pdf/ev-poppler.cc
@@ -2695,6 +2695,9 @@ ev_annot_from_poppler_annot (PopplerAnnot *poppler_annot,
 	        case POPPLER_ANNOT_UNDERLINE:
 			ev_annot = ev_annotation_text_markup_underline_new (page);
 			break;
+	        case POPPLER_ANNOT_SQUIGGLY:
+			ev_annot = ev_annotation_text_markup_squiggly_new (page);
+			break;
 	        case POPPLER_ANNOT_LINK:
 	        case POPPLER_ANNOT_WIDGET:
 			/* Ignore link and widgets annots since they are already handled */

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -68,6 +68,8 @@ struct _EvAnnotationAttachmentClass {
 
 struct _EvAnnotationTextMarkup {
 	EvAnnotation parent;
+
+	EvAnnotationTextMarkupType type;
 };
 
 struct _EvAnnotationTextMarkupClass {
@@ -108,6 +110,11 @@ enum {
 /* EvAnnotationAttachment */
 enum {
 	PROP_ATTACHMENT_ATTACHMENT = PROP_MARKUP_POPUP_IS_OPEN + 1
+};
+
+/* EvAnnotationTextMarkup */
+enum {
+	PROP_TEXT_MARKUP_TYPE = PROP_MARKUP_POPUP_IS_OPEN + 1
 };
 
 G_DEFINE_ABSTRACT_TYPE (EvAnnotation, ev_annotation, G_TYPE_OBJECT)
@@ -1237,6 +1244,51 @@ ev_annotation_attachment_set_attachment (EvAnnotationAttachment *annot,
 static void
 ev_annotation_text_markup_init (EvAnnotationTextMarkup *annot)
 {
+	EV_ANNOTATION (annot)->type = EV_ANNOTATION_TYPE_TEXT_MARKUP;
+}
+
+static void
+ev_annotation_text_markup_set_property (GObject      *object,
+                                        guint         prop_id,
+                                        const GValue *value,
+                                        GParamSpec   *pspec)
+{
+	EvAnnotationTextMarkup *annot = EV_ANNOTATION_TEXT_MARKUP (object);
+
+	if (prop_id < PROP_TEXT_MARKUP_TYPE) {
+		ev_annotation_markup_set_property (object, prop_id, value, pspec);
+		return;
+	}
+
+	switch (prop_id) {
+	case PROP_TEXT_MARKUP_TYPE:
+		annot->type = (EvAnnotationTextMarkupType) g_value_get_enum (value);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+	}
+}
+
+static void
+ev_annotation_text_markup_get_property (GObject    *object,
+                                        guint       prop_id,
+                                        GValue     *value,
+                                        GParamSpec *pspec)
+{
+	EvAnnotationTextMarkup *annot = EV_ANNOTATION_TEXT_MARKUP (object);
+
+	if (prop_id < PROP_TEXT_MARKUP_TYPE) {
+		ev_annotation_markup_get_property (object, prop_id, value, pspec);
+		return;
+	}
+
+	switch (prop_id) {
+	case PROP_TEXT_MARKUP_TYPE:
+		g_value_set_enum (value, annot->type);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+	}
 }
 
 static void
@@ -1245,6 +1297,18 @@ ev_annotation_text_markup_class_init (EvAnnotationTextMarkupClass *klass)
 	GObjectClass *g_object_class = G_OBJECT_CLASS (klass);
 
 	ev_annotation_markup_class_install_properties (g_object_class);
+
+	g_object_class->set_property = ev_annotation_text_markup_set_property;
+	g_object_class->get_property = ev_annotation_text_markup_get_property;
+
+	g_object_class_install_property (g_object_class,
+	                                 PROP_TEXT_MARKUP_TYPE,
+	                                 g_param_spec_enum ("type",
+	                                                    "Type",
+	                                                    "The text markup annotation type",
+	                                                    EV_TYPE_ANNOTATION_TEXT_MARKUP_TYPE,
+	                                                    EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT,
+	                                                    G_PARAM_READWRITE));
 }
 
 static void
@@ -1255,10 +1319,8 @@ ev_annotation_text_markup_markup_iface_init (EvAnnotationMarkupInterface *iface)
 EvAnnotation *
 ev_annotation_text_markup_highlight_new (EvPage *page)
 {
-	EvAnnotation *annot = EV_ANNOTATION (g_object_new (EV_TYPE_ANNOTATION_TEXT_MARKUP,
-	                                                   "page", page,
-	                                                   NULL));
-	annot->type = EV_ANNOTATION_TYPE_HIGHLIGHT;
-
-	return annot;
+	return EV_ANNOTATION (g_object_new (EV_TYPE_ANNOTATION_TEXT_MARKUP,
+	                                    "page", page,
+	                                    "type", EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT,
+	                                    NULL));
 }

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -1324,3 +1324,20 @@ ev_annotation_text_markup_highlight_new (EvPage *page)
 	                                    "type", EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT,
 	                                    NULL));
 }
+
+EvAnnotation *
+ev_annotation_text_markup_strike_out_new (EvPage *page)
+{
+	return EV_ANNOTATION (g_object_new (EV_TYPE_ANNOTATION_TEXT_MARKUP,
+	                                    "page", page,
+	                                    "type", EV_ANNOTATION_TEXT_MARKUP_STRIKE_OUT,
+	                                    NULL));
+}
+
+EvAnnotationTextMarkupType
+ev_annotation_text_markup_get_markup_type (EvAnnotationTextMarkup *annot)
+{
+	g_return_val_if_fail (EV_IS_ANNOTATION_TEXT_MARKUP (annot), 0);
+
+	return annot->type;
+}

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -1251,3 +1251,14 @@ static void
 ev_annotation_text_markup_markup_iface_init (EvAnnotationMarkupInterface *iface)
 {
 }
+
+EvAnnotation *
+ev_annotation_text_markup_highlight_new (EvPage *page)
+{
+	EvAnnotation *annot = EV_ANNOTATION (g_object_new (EV_TYPE_ANNOTATION_TEXT_MARKUP,
+	                                                   "page", page,
+	                                                   NULL));
+	annot->type = EV_ANNOTATION_TYPE_HIGHLIGHT;
+
+	return annot;
+}

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -1343,6 +1343,15 @@ ev_annotation_text_markup_underline_new (EvPage *page)
 	                                    NULL));
 }
 
+EvAnnotation *
+ev_annotation_text_markup_squiggly_new (EvPage *page)
+{
+	return EV_ANNOTATION (g_object_new (EV_TYPE_ANNOTATION_TEXT_MARKUP,
+	                                    "page", page,
+	                                    "type", EV_ANNOTATION_TEXT_MARKUP_SQUIGGLY,
+	                                    NULL));
+}
+
 EvAnnotationTextMarkupType
 ev_annotation_text_markup_get_markup_type (EvAnnotationTextMarkup *annot)
 {

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -1334,6 +1334,15 @@ ev_annotation_text_markup_strike_out_new (EvPage *page)
 	                                    NULL));
 }
 
+EvAnnotation *
+ev_annotation_text_markup_underline_new (EvPage *page)
+{
+	return EV_ANNOTATION (g_object_new (EV_TYPE_ANNOTATION_TEXT_MARKUP,
+	                                    "page", page,
+	                                    "type", EV_ANNOTATION_TEXT_MARKUP_UNDERLINE,
+	                                    NULL));
+}
+
 EvAnnotationTextMarkupType
 ev_annotation_text_markup_get_markup_type (EvAnnotationTextMarkup *annot)
 {

--- a/libdocument/ev-annotation.c
+++ b/libdocument/ev-annotation.c
@@ -66,7 +66,16 @@ struct _EvAnnotationAttachmentClass {
 	EvAnnotationClass parent_class;
 };
 
-static void ev_annotation_text_markup_iface_init       (EvAnnotationMarkupInterface *iface);
+struct _EvAnnotationTextMarkup {
+	EvAnnotation parent;
+};
+
+struct _EvAnnotationTextMarkupClass {
+	EvAnnotationClass parent_class;
+};
+
+static void ev_annotation_text_markup_iface_init             (EvAnnotationMarkupInterface *iface);
+static void ev_annotation_text_markup_markup_iface_init      (EvAnnotationMarkupInterface *iface);
 static void ev_annotation_attachment_markup_iface_init (EvAnnotationMarkupInterface *iface);
 
 /* EvAnnotation */
@@ -112,6 +121,11 @@ G_DEFINE_TYPE_WITH_CODE (EvAnnotationAttachment, ev_annotation_attachment, EV_TY
 	 {
 		 G_IMPLEMENT_INTERFACE (EV_TYPE_ANNOTATION_MARKUP,
 					ev_annotation_attachment_markup_iface_init);
+	 });
+G_DEFINE_TYPE_WITH_CODE (EvAnnotationTextMarkup, ev_annotation_text_markup, EV_TYPE_ANNOTATION,
+	 {
+		 G_IMPLEMENT_INTERFACE (EV_TYPE_ANNOTATION_MARKUP,
+					ev_annotation_text_markup_markup_iface_init);
 	 });
 
 /* EvAnnotation */
@@ -1217,4 +1231,23 @@ ev_annotation_attachment_set_attachment (EvAnnotationAttachment *annot,
 	g_object_notify (G_OBJECT (annot), "attachment");
 
 	return TRUE;
+}
+
+/* EvAnnotationTextMarkup */
+static void
+ev_annotation_text_markup_init (EvAnnotationTextMarkup *annot)
+{
+}
+
+static void
+ev_annotation_text_markup_class_init (EvAnnotationTextMarkupClass *klass)
+{
+	GObjectClass *g_object_class = G_OBJECT_CLASS (klass);
+
+	ev_annotation_markup_class_install_properties (g_object_class);
+}
+
+static void
+ev_annotation_text_markup_markup_iface_init (EvAnnotationMarkupInterface *iface)
+{
 }

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -111,7 +111,8 @@ typedef enum {
 } EvAnnotationTextIcon;
 
 typedef enum {
-	EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT
+	EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT,
+	EV_ANNOTATION_TEXT_MARKUP_STRIKE_OUT
 } EvAnnotationTextMarkupType;
 
 /* EvAnnotation */
@@ -181,8 +182,10 @@ gboolean             ev_annotation_attachment_set_attachment (EvAnnotationAttach
 							      EvAttachment           *attachment);
 
 /* EvAnnotationTextMarkup */
-GType                ev_annotation_text_markup_get_type     (void) G_GNUC_CONST;
-EvAnnotation        *ev_annotation_text_markup_highlight_new (EvPage *page);
+GType                          ev_annotation_text_markup_get_type        (void) G_GNUC_CONST;
+EvAnnotation                  *ev_annotation_text_markup_highlight_new  (EvPage *page);
+EvAnnotation                  *ev_annotation_text_markup_strike_out_new (EvPage *page);
+EvAnnotationTextMarkupType     ev_annotation_text_markup_get_markup_type (EvAnnotationTextMarkup *annot);
 
 G_END_DECLS
 

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -93,7 +93,8 @@ typedef struct _EvAnnotationTextMarkupClass EvAnnotationTextMarkupClass;
 typedef enum {
 	EV_ANNOTATION_TYPE_UNKNOWN,
 	EV_ANNOTATION_TYPE_TEXT,
-	EV_ANNOTATION_TYPE_ATTACHMENT
+	EV_ANNOTATION_TYPE_ATTACHMENT,
+	EV_ANNOTATION_TYPE_HIGHLIGHT
 } EvAnnotationType;
 
 typedef enum {
@@ -177,6 +178,7 @@ gboolean             ev_annotation_attachment_set_attachment (EvAnnotationAttach
 
 /* EvAnnotationTextMarkup */
 GType                ev_annotation_text_markup_get_type     (void) G_GNUC_CONST;
+EvAnnotation        *ev_annotation_text_markup_highlight_new (EvPage *page);
 
 G_END_DECLS
 

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -113,7 +113,8 @@ typedef enum {
 typedef enum {
 	EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT,
 	EV_ANNOTATION_TEXT_MARKUP_STRIKE_OUT,
-	EV_ANNOTATION_TEXT_MARKUP_UNDERLINE
+	EV_ANNOTATION_TEXT_MARKUP_UNDERLINE,
+	EV_ANNOTATION_TEXT_MARKUP_SQUIGGLY
 } EvAnnotationTextMarkupType;
 
 /* EvAnnotation */
@@ -187,6 +188,7 @@ GType                          ev_annotation_text_markup_get_type        (void) 
 EvAnnotation                  *ev_annotation_text_markup_highlight_new  (EvPage *page);
 EvAnnotation                  *ev_annotation_text_markup_strike_out_new (EvPage *page);
 EvAnnotation                  *ev_annotation_text_markup_underline_new  (EvPage *page);
+EvAnnotation                  *ev_annotation_text_markup_squiggly_new   (EvPage *page);
 EvAnnotationTextMarkupType     ev_annotation_text_markup_get_markup_type (EvAnnotationTextMarkup *annot);
 
 G_END_DECLS

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -94,7 +94,7 @@ typedef enum {
 	EV_ANNOTATION_TYPE_UNKNOWN,
 	EV_ANNOTATION_TYPE_TEXT,
 	EV_ANNOTATION_TYPE_ATTACHMENT,
-	EV_ANNOTATION_TYPE_HIGHLIGHT
+	EV_ANNOTATION_TYPE_TEXT_MARKUP
 } EvAnnotationType;
 
 typedef enum {
@@ -109,6 +109,10 @@ typedef enum {
 	EV_ANNOTATION_TEXT_ICON_CIRCLE,
 	EV_ANNOTATION_TEXT_ICON_UNKNOWN
 } EvAnnotationTextIcon;
+
+typedef enum {
+	EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT
+} EvAnnotationTextMarkupType;
 
 /* EvAnnotation */
 GType                ev_annotation_get_type                  (void) G_GNUC_CONST;

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -112,7 +112,8 @@ typedef enum {
 
 typedef enum {
 	EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT,
-	EV_ANNOTATION_TEXT_MARKUP_STRIKE_OUT
+	EV_ANNOTATION_TEXT_MARKUP_STRIKE_OUT,
+	EV_ANNOTATION_TEXT_MARKUP_UNDERLINE
 } EvAnnotationTextMarkupType;
 
 /* EvAnnotation */
@@ -185,6 +186,7 @@ gboolean             ev_annotation_attachment_set_attachment (EvAnnotationAttach
 GType                          ev_annotation_text_markup_get_type        (void) G_GNUC_CONST;
 EvAnnotation                  *ev_annotation_text_markup_highlight_new  (EvPage *page);
 EvAnnotation                  *ev_annotation_text_markup_strike_out_new (EvPage *page);
+EvAnnotation                  *ev_annotation_text_markup_underline_new  (EvPage *page);
 EvAnnotationTextMarkupType     ev_annotation_text_markup_get_markup_type (EvAnnotationTextMarkup *annot);
 
 G_END_DECLS

--- a/libdocument/ev-annotation.h
+++ b/libdocument/ev-annotation.h
@@ -59,13 +59,21 @@ G_BEGIN_DECLS
 #define EV_IS_ANNOTATION_TEXT_CLASS(klass)      (G_TYPE_CHECK_CLASS_TYPE((klass), EV_TYPE_ANNOTATION_TEXT))
 #define EV_ANNOTATION_TEXT_GET_CLASS(object)    (G_TYPE_INSTANCE_GET_CLASS((object), EV_TYPE_ANNOTATION_TEXT, EvAnnotationTextClass))
 
-/* EvAnnotationText */
+/* EvAnnotationAttachment */
 #define EV_TYPE_ANNOTATION_ATTACHMENT              (ev_annotation_attachment_get_type())
 #define EV_ANNOTATION_ATTACHMENT(object)           (G_TYPE_CHECK_INSTANCE_CAST((object), EV_TYPE_ANNOTATION_ATTACHMENT, EvAnnotationAttachment))
 #define EV_ANNOTATION_ATTACHMENT_CLASS(klass)      (G_TYPE_CHECK_CLASS_CAST((klass), EV_TYPE_ANNOTATION_ATTACHMENT, EvAnnotationAttachmentClass))
 #define EV_IS_ANNOTATION_ATTACHMENT(object)        (G_TYPE_CHECK_INSTANCE_TYPE((object), EV_TYPE_ANNOTATION_ATTACHMENT))
 #define EV_IS_ANNOTATION_ATTACHMENT_CLASS(klass)   (G_TYPE_CHECK_CLASS_TYPE((klass), EV_TYPE_ANNOTATION_ATTACHMENT))
 #define EV_ANNOTATION_ATTACHMENT_GET_CLASS(object) (G_TYPE_INSTANCE_GET_CLASS((object), EV_TYPE_ANNOTATION_ATTACHMENT, EvAnnotationAttachmentClass))
+
+/* EvAnnotationTextMarkup */
+#define EV_TYPE_ANNOTATION_TEXT_MARKUP                 (ev_annotation_text_markup_get_type())
+#define EV_ANNOTATION_TEXT_MARKUP(object)              (G_TYPE_CHECK_INSTANCE_CAST((object), EV_TYPE_ANNOTATION_TEXT_MARKUP, EvAnnotationTextMarkup))
+#define EV_ANNOTATION_TEXT_MARKUP_CLASS(klass)         (G_TYPE_CHECK_CLASS_CAST((klass), EV_TYPE_ANNOTATION_TEXT_MARKUP, EvAnnotationTextMarkupClass))
+#define EV_IS_ANNOTATION_TEXT_MARKUP(object)           (G_TYPE_CHECK_INSTANCE_TYPE((object), EV_TYPE_ANNOTATION_TEXT_MARKUP))
+#define EV_IS_ANNOTATION_TEXT_MARKUP_CLASS(klass)      (G_TYPE_CHECK_CLASS_TYPE((klass), EV_TYPE_ANNOTATION_TEXT_MARKUP))
+#define EV_ANNOTATION_TEXT_MARKUP_GET_CLASS(object)    (G_TYPE_INSTANCE_GET_CLASS((object), EV_TYPE_ANNOTATION_TEXT_MARKUP, EvAnnotationTextMarkupClass))
 
 typedef struct _EvAnnotation                EvAnnotation;
 typedef struct _EvAnnotationClass           EvAnnotationClass;
@@ -78,6 +86,9 @@ typedef struct _EvAnnotationTextClass       EvAnnotationTextClass;
 
 typedef struct _EvAnnotationAttachment      EvAnnotationAttachment;
 typedef struct _EvAnnotationAttachmentClass EvAnnotationAttachmentClass;
+
+typedef struct _EvAnnotationTextMarkup      EvAnnotationTextMarkup;
+typedef struct _EvAnnotationTextMarkupClass EvAnnotationTextMarkupClass;
 
 typedef enum {
 	EV_ANNOTATION_TYPE_UNKNOWN,
@@ -163,6 +174,9 @@ EvAnnotation        *ev_annotation_attachment_new            (EvPage            
 EvAttachment        *ev_annotation_attachment_get_attachment (EvAnnotationAttachment *annot);
 gboolean             ev_annotation_attachment_set_attachment (EvAnnotationAttachment *annot,
 							      EvAttachment           *attachment);
+
+/* EvAnnotationTextMarkup */
+GType                ev_annotation_text_markup_get_type     (void) G_GNUC_CONST;
 
 G_END_DECLS
 

--- a/shell/ev-sidebar-annotations.c
+++ b/shell/ev-sidebar-annotations.c
@@ -335,6 +335,7 @@ job_finished_callback (EvJobAnnots          *job,
 	GdkPixbuf *attachment_icon = NULL;
 	GdkPixbuf *highlight_icon = NULL;
 	GdkPixbuf *strike_out_icon = NULL;
+	GdkPixbuf *underline_icon = NULL;
 
 	priv = sidebar_annots->priv;
 
@@ -445,6 +446,16 @@ job_finished_callback (EvJobAnnots          *job,
 					}
 					pixbuf = strike_out_icon;
 					break;
+				case EV_ANNOTATION_TEXT_MARKUP_UNDERLINE:
+					if (!underline_icon) {
+						underline_icon = gtk_icon_theme_load_icon (icon_theme,
+						                                            "format-text-underline",
+						                                            GTK_ICON_SIZE_BUTTON,
+						                                            GTK_ICON_LOOKUP_FORCE_REGULAR,
+						                                            NULL);
+					}
+					pixbuf = underline_icon;
+					break;
 				default:
 					break;
 				}
@@ -476,6 +487,8 @@ job_finished_callback (EvJobAnnots          *job,
 		g_object_unref (highlight_icon);
 	if (strike_out_icon)
 		g_object_unref (strike_out_icon);
+	if (underline_icon)
+		g_object_unref (underline_icon);
 
 	g_object_unref (job);
 	priv->job = NULL;

--- a/shell/ev-sidebar-annotations.c
+++ b/shell/ev-sidebar-annotations.c
@@ -333,6 +333,7 @@ job_finished_callback (EvJobAnnots          *job,
 	GList *l;
 	GdkPixbuf *text_icon = NULL;
 	GdkPixbuf *attachment_icon = NULL;
+	GdkPixbuf *highlight_icon = NULL;
 
 	priv = sidebar_annots->priv;
 
@@ -421,6 +422,15 @@ job_finished_callback (EvJobAnnots          *job,
 					                                            NULL);
 				}
 				pixbuf = attachment_icon;
+			} else if (EV_IS_ANNOTATION_TEXT_MARKUP (annot)) {
+				if (!highlight_icon) {
+					highlight_icon = gtk_icon_theme_load_icon (icon_theme,
+					                                           "edit-select-all",
+					                                           GTK_ICON_SIZE_BUTTON,
+					                                           GTK_ICON_LOOKUP_FORCE_REGULAR,
+					                                           NULL);
+				}
+				pixbuf = highlight_icon;
 			}
 
 			gtk_tree_store_append (model, &child_iter, &iter);
@@ -445,6 +455,8 @@ job_finished_callback (EvJobAnnots          *job,
 		g_object_unref (text_icon);
 	if (attachment_icon)
 		g_object_unref (attachment_icon);
+	if (highlight_icon)
+		g_object_unref (highlight_icon);
 
 	g_object_unref (job);
 	priv->job = NULL;

--- a/shell/ev-sidebar-annotations.c
+++ b/shell/ev-sidebar-annotations.c
@@ -334,6 +334,7 @@ job_finished_callback (EvJobAnnots          *job,
 	GdkPixbuf *text_icon = NULL;
 	GdkPixbuf *attachment_icon = NULL;
 	GdkPixbuf *highlight_icon = NULL;
+	GdkPixbuf *strike_out_icon = NULL;
 
 	priv = sidebar_annots->priv;
 
@@ -423,14 +424,30 @@ job_finished_callback (EvJobAnnots          *job,
 				}
 				pixbuf = attachment_icon;
 			} else if (EV_IS_ANNOTATION_TEXT_MARKUP (annot)) {
-				if (!highlight_icon) {
-					highlight_icon = gtk_icon_theme_load_icon (icon_theme,
-					                                           "edit-select-all",
-					                                           GTK_ICON_SIZE_BUTTON,
-					                                           GTK_ICON_LOOKUP_FORCE_REGULAR,
-					                                           NULL);
+				switch (ev_annotation_text_markup_get_markup_type (EV_ANNOTATION_TEXT_MARKUP (annot))) {
+				case EV_ANNOTATION_TEXT_MARKUP_HIGHLIGHT:
+					if (!highlight_icon) {
+						highlight_icon = gtk_icon_theme_load_icon (icon_theme,
+						                                           "edit-select-all",
+						                                           GTK_ICON_SIZE_BUTTON,
+						                                           GTK_ICON_LOOKUP_FORCE_REGULAR,
+						                                           NULL);
+					}
+					pixbuf = highlight_icon;
+					break;
+				case EV_ANNOTATION_TEXT_MARKUP_STRIKE_OUT:
+					if (!strike_out_icon) {
+						strike_out_icon = gtk_icon_theme_load_icon (icon_theme,
+						                                             "format-text-strikethrough",
+						                                             GTK_ICON_SIZE_BUTTON,
+						                                             GTK_ICON_LOOKUP_FORCE_REGULAR,
+						                                             NULL);
+					}
+					pixbuf = strike_out_icon;
+					break;
+				default:
+					break;
 				}
-				pixbuf = highlight_icon;
 			}
 
 			gtk_tree_store_append (model, &child_iter, &iter);
@@ -457,6 +474,8 @@ job_finished_callback (EvJobAnnots          *job,
 		g_object_unref (attachment_icon);
 	if (highlight_icon)
 		g_object_unref (highlight_icon);
+	if (strike_out_icon)
+		g_object_unref (strike_out_icon);
 
 	g_object_unref (job);
 	priv->job = NULL;

--- a/shell/ev-sidebar-annotations.c
+++ b/shell/ev-sidebar-annotations.c
@@ -336,6 +336,7 @@ job_finished_callback (EvJobAnnots          *job,
 	GdkPixbuf *highlight_icon = NULL;
 	GdkPixbuf *strike_out_icon = NULL;
 	GdkPixbuf *underline_icon = NULL;
+	GdkPixbuf *squiggly_icon = NULL;
 
 	priv = sidebar_annots->priv;
 
@@ -456,6 +457,16 @@ job_finished_callback (EvJobAnnots          *job,
 					}
 					pixbuf = underline_icon;
 					break;
+				case EV_ANNOTATION_TEXT_MARKUP_SQUIGGLY:
+					if (!squiggly_icon) {
+						squiggly_icon = gtk_icon_theme_load_icon (icon_theme,
+						                                           "format-text-underline",
+						                                           GTK_ICON_SIZE_BUTTON,
+						                                           GTK_ICON_LOOKUP_FORCE_REGULAR,
+						                                           NULL);
+					}
+					pixbuf = squiggly_icon;
+					break;
 				default:
 					break;
 				}
@@ -489,6 +500,8 @@ job_finished_callback (EvJobAnnots          *job,
 		g_object_unref (strike_out_icon);
 	if (underline_icon)
 		g_object_unref (underline_icon);
+	if (squiggly_icon)
+		g_object_unref (squiggly_icon);
 
 	g_object_unref (job);
 	priv->job = NULL;


### PR DESCRIPTION
This adds read-only support for viewing highlight annotations. All commits backported directly from Evince.

Fixes #691

I've included some attachments from the original [bugzilla report](https://bugzilla.gnome.org/show_bug.cgi?id=583377):
- [attachment_135054.pdf](https://github.com/user-attachments/files/27731736/attachment_135054.pdf)
- [attachment_200171.pdf](https://github.com/user-attachments/files/27731737/attachment_200171.pdf)

and a screenshot with an annotation open and the sidebar listing all annotations:
<img width="1919" height="2038" alt="Screenshot at 2026-05-13 16-34-22" src="https://github.com/user-attachments/assets/2de11405-4f14-4a0d-b378-a22d01f02a45" />
