### PR TITLE
ev-application: Quote user-supplied strings in ev_spawn command line

### DIFF
--- a/shell/ev-application.c
+++ b/shell/ev-application.c
@@ -221,18 +221,22 @@ ev_spawn (const char     *uri,
 	/* Page label or index */
 	if (dest) {
 		switch (ev_link_dest_get_dest_type (dest)) {
-		case EV_LINK_DEST_TYPE_PAGE_LABEL:
-			g_string_append_printf (cmd, " --page-label=%s",
-			                        ev_link_dest_get_page_label (dest));
+		case EV_LINK_DEST_TYPE_PAGE_LABEL: {
+			gchar *quoted = g_shell_quote (ev_link_dest_get_page_label (dest));
+			g_string_append_printf (cmd, " --page-label=%s", quoted);
+			g_free (quoted);
 			break;
+		}
 		case EV_LINK_DEST_TYPE_PAGE:
 			g_string_append_printf (cmd, " --page-index=%d",
 			                        ev_link_dest_get_page (dest) + 1);
 			break;
-		case EV_LINK_DEST_TYPE_NAMED:
-		g_string_append_printf (cmd, " --named-dest=%s",
-			                    ev_link_dest_get_named_dest (dest));
+		case EV_LINK_DEST_TYPE_NAMED: {
+			gchar *quoted = g_shell_quote (ev_link_dest_get_named_dest (dest));
+			g_string_append_printf (cmd, " --named-dest=%s", quoted);
+			g_free (quoted);
 			break;
+		}
 		default:
 			break;
 		}
@@ -240,7 +244,9 @@ ev_spawn (const char     *uri,
 
 	/* Find string */
 	if (search_string) {
-		g_string_append_printf (cmd, " --find=%s", search_string);
+		gchar *quoted = g_shell_quote (search_string);
+		g_string_append_printf (cmd, " --find=%s", quoted);
+		g_free (quoted);
 	}
 
 	/* Mode */


### PR DESCRIPTION
When spawning a new atril instance for cross-document links, the destination and search parameters from the document were interpolated directly into the command line without shell quoting. Values containing spaces or special characters could be split into separate arguments by the shell parser, potentially being interpreted as unintended flags by the child process.

Apply shell quoting to page label, named destination, and search string values before appending them to the command line, consistent with how other spawn sites in the codebase already handle this.