### PR TITLE
build: Distribute meson build files when using autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,7 +45,43 @@ header_DATA = \
 EXTRA_DIST =            \
     $(header_DATA)      \
     autogen.sh          \
-    README.md
+    README.md           \
+    meson.build         \
+    meson_options.txt   \
+    backend/meson.build \
+    backend/comics/meson.build \
+    backend/djvu/meson.build \
+    backend/dvi/meson.build \
+    backend/dvi/mdvi-lib/meson.build \
+    backend/epub/meson.build \
+    backend/epub/minizip/meson.build \
+    backend/pdf/meson.build \
+    backend/pixbuf/meson.build \
+    backend/ps/meson.build \
+    backend/tiff/meson.build \
+    backend/xps/meson.build \
+    cut-n-paste/toolbar-editor/meson.build \
+    cut-n-paste/zoom-control/meson.build \
+    data/meson.build \
+    data/icons/meson.build \
+    help/meson.build \
+    help/reference/libdocument/meson.build \
+    help/reference/libview/meson.build \
+    help/reference/shell/meson.build \
+    install-scripts/meson.build \
+    install-scripts/meson_install_schemas.py \
+    install-scripts/meson_update_icon_cache.py \
+    install-scripts/meson_update_mime_database.py \
+    libdocument/meson.build \
+    libmisc/meson.build \
+    libview/meson.build \
+    po/meson.build \
+    previewer/meson.build \
+    properties/meson.build \
+    shell/meson.build \
+    test/meson.build \
+    thumbnailer/meson.build \
+    subprojects/mate-submodules.wrap
 
 DISTCLEANFILES =
 

--- a/backend/comics/Makefile.am
+++ b/backend/comics/Makefile.am
@@ -32,7 +32,7 @@ else
 	$(AM_V_GEN) cp -f $< $@
 endif
 
-EXTRA_DIST = $(backend_in_files)
+EXTRA_DIST = $(backend_in_files) test-ev-archive.c
 
 CLEANFILES = $(backend_DATA)
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -42,7 +42,6 @@ option('xps',
 )
 option('caja',
     type: 'feature',
-    value: 'enabled',
     description: 'Support for the Caja extension'
 )
 option('gtk_unix_print',

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -14,6 +14,16 @@ EXTRA_DIST = \
 	test-mime.bin \
 	test-page-labels.pdf \
 	test6.py \
-	test7.py
+	test7.py \
+	testBookmarksMenu.py \
+	testCommon.py \
+	testEditMenu.py \
+	testEncryptedFile.py \
+	testFileMenu.py \
+	testFileReloading.py \
+	testGoMenu.py \
+	testHelpMenu.py \
+	testWrongFileExtension.py \
+	testZoom.py
 
 -include $(top_srcdir)/git.mk


### PR DESCRIPTION
build: Distribute meson build files when using autotools

Fixes #673

Backported from https://gitlab.gnome.org/GNOME/evince/-/commit/021428c9