### PR TITLE
Standardize height of action_widget

### DIFF
--- a/libmisc/ev-page-action-widget.c
+++ b/libmisc/ev-page-action-widget.c
@@ -183,7 +183,6 @@ ev_page_action_widget_init (EvPageActionWidget *action_widget)
 			    FALSE, FALSE, 0);
 	gtk_widget_show (action_widget->label);
 
-	gtk_container_set_border_width (GTK_CONTAINER (action_widget), 6);
 	gtk_container_add (GTK_CONTAINER (action_widget), hbox);
 	gtk_widget_show (hbox);
 


### PR DESCRIPTION
The action widget is the only one with a nonstandard height, 6px above the others. When it's included, it slightly expands the thickness of the toolbar. This PR mitigates this and keeps the toolbar at a constant height as a result.