### PR TITLE
Only display supported filetypes in Recent Files list

### DIFF
--- a/libdocument/ev-backends-manager.c
+++ b/libdocument/ev-backends-manager.c
@@ -217,6 +217,20 @@ ev_backends_manager_get_backend_info (const gchar *mime_type)
 	return NULL;
 }
 
+gboolean
+ev_backends_manager_mime_type_supported (const gchar *mime_type)
+{
+	if (ev_backends_manager_get_backend_info (mime_type))
+		return TRUE;
+
+#ifdef ENABLE_PIXBUF
+	if (ev_document_factory_mime_type_supported_by_gdk_pixbuf (mime_type))
+		return TRUE;
+#endif
+
+	return FALSE;
+}
+
 EvDocument *
 ev_backends_manager_get_document (const gchar *mime_type)
 {

--- a/libdocument/ev-backends-manager.h
+++ b/libdocument/ev-backends-manager.h
@@ -39,6 +39,7 @@ typedef struct _EvTypeInfo {
 gboolean    _ev_backends_manager_init                     (void);
 void        _ev_backends_manager_shutdown                 (void);
 
+gboolean    ev_backends_manager_mime_type_supported       (const gchar *mime_type);
 EvDocument  *ev_backends_manager_get_document             (const gchar *mime_type);
 
 EV_DEPRECATED

--- a/libdocument/ev-document-factory.c
+++ b/libdocument/ev-document-factory.c
@@ -87,7 +87,7 @@ mime_type_supported_by_gdk_pixbuf (const gchar *mime_type)
 gboolean
 ev_document_factory_mime_type_supported_by_gdk_pixbuf (const gchar *mime_type)
 {
-    return mime_type_supported_by_gdk_pixbuf (mime_type);
+	return mime_type_supported_by_gdk_pixbuf (mime_type);
 }
 #endif /* ENABLE_PIXBUF */
 

--- a/libdocument/ev-document-factory.c
+++ b/libdocument/ev-document-factory.c
@@ -83,6 +83,12 @@ mime_type_supported_by_gdk_pixbuf (const gchar *mime_type)
 
 	return retval;
 }
+
+gboolean
+ev_document_factory_mime_type_supported_by_gdk_pixbuf (const gchar *mime_type)
+{
+    return mime_type_supported_by_gdk_pixbuf (mime_type);
+}
 #endif /* ENABLE_PIXBUF */
 
 static EvCompressionType

--- a/libdocument/ev-document-factory.h
+++ b/libdocument/ev-document-factory.h
@@ -31,8 +31,9 @@
 
 G_BEGIN_DECLS
 
-EvDocument* ev_document_factory_get_document (const char *uri, GError **error);
-void 	    ev_document_factory_add_filters  (GtkWidget *chooser, EvDocument *document);
+EvDocument* ev_document_factory_get_document                      (const char *uri, GError **error);
+void 	    ev_document_factory_add_filters                       (GtkWidget *chooser, EvDocument *document);
+gboolean    ev_document_factory_mime_type_supported_by_gdk_pixbuf (const gchar *mime_type);
 
 G_END_DECLS
 

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -3055,7 +3055,7 @@ ev_window_setup_recent (EvWindow *ev_window)
                         g_object_unref (icon);
 
 		if (++n_items == 10)
-            break;
+			break;
 	}
 
 	g_list_foreach (items, (GFunc) gtk_recent_info_unref, NULL);

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -3001,29 +3001,21 @@ ev_window_setup_recent (EvWindow *ev_window)
 		    (gtk_recent_info_is_local (info) && !gtk_recent_info_exists (info)))
 			continue;
 
-		action_name = g_strdup_printf ("RecentFile%u", i++);
-		label = ev_window_get_recent_file_label (
-			(n_items + 1) % 10, gtk_recent_info_get_display_name (info));
-
 		mime_type = gtk_recent_info_get_mime_type (info);
 		if (!mime_type)
 			continue;
 
-		/* Check if Atril has a backend for this MIME type */
-		if (!ev_backends_manager_get_document(mime_type)) {
-		#ifdef ENABLE_PIXBUF
-			/* Allow image backend if pixbuf support enabled */
-			if (!mime_type_supported_by_gdk_pixbuf(mime_type))
-				continue;
-		#else
+		if (!ev_backends_manager_mime_type_supported (mime_type))
 			continue;
-		#endif
-		}
+
+		action_name = g_strdup_printf ("RecentFile%u", i++);
+		label = ev_window_get_recent_file_label (
+			(n_items + 1) % 10, gtk_recent_info_get_display_name (info));
 
 		content_type = g_content_type_from_mime_type (mime_type);
 		if (content_type != NULL) {
-				icon = g_content_type_get_icon (content_type);
-				g_free (content_type);
+			icon = g_content_type_get_icon (content_type);
+			g_free (content_type);
 		}
 
 		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
@@ -3063,7 +3055,7 @@ ev_window_setup_recent (EvWindow *ev_window)
                         g_object_unref (icon);
 
 		if (++n_items == 10)
-			break;
+            break;
 	}
 
 	g_list_foreach (items, (GFunc) gtk_recent_info_unref, NULL);

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -3005,12 +3005,27 @@ ev_window_setup_recent (EvWindow *ev_window)
 		label = ev_window_get_recent_file_label (
 			(n_items + 1) % 10, gtk_recent_info_get_display_name (info));
 
-                mime_type = gtk_recent_info_get_mime_type (info);
-                content_type = g_content_type_from_mime_type (mime_type);
-                if (content_type != NULL) {
-                        icon = g_content_type_get_icon (content_type);
-                        g_free (content_type);
-                }
+		mime_type = gtk_recent_info_get_mime_type (info);
+		if (!mime_type)
+			continue;
+
+		/* Check if Atril has a backend for this MIME type */
+		if (!ev_backends_manager_get_document(mime_type)) {
+		#ifdef ENABLE_PIXBUF
+			/* Allow image backend if pixbuf support enabled */
+			if (!mime_type_supported_by_gdk_pixbuf(mime_type))
+				continue;
+		#else
+			continue;
+		#endif
+		}
+
+		content_type = g_content_type_from_mime_type (mime_type);
+		if (content_type != NULL) {
+				icon = g_content_type_get_icon (content_type);
+				g_free (content_type);
+		}
+
 		G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 		action = g_object_new (GTK_TYPE_ACTION,
 				       "name", action_name,


### PR DESCRIPTION
Presently, Recent Files also displays various files that Atril can't open, e.g. if I try and fail to open a file with an unsupported extension, or when I right click and Save Image As... This PR aims to filter the Recent Files list down to only files supported by Atril.