### PR TITLE
Allow inverted colors to be set as default via gsettings

### DIFF
--- a/data/org.mate.Atril.gschema.xml
+++ b/data/org.mate.Atril.gschema.xml
@@ -40,39 +40,63 @@
   <schema id="org.mate.Atril.Default" path="/org/mate/atril/default/" gettext-domain="atril">
     <key name="show-toolbar" type="b">
       <default>true</default>
+      <summary>Show toolbar</summary>
+      <description>Whether to show the toolbar.</description>
     </key>
     <key name="show-sidebar" type="b">
       <default>true</default>
+      <summary>Show side pane</summary>
+      <description>Whether to show the side pane.</description>
     </key>
     <key name="window-ratio" type="(dd)">
       <default>(0., 0.)</default>
+      <summary>Default window size ratio</summary>
+      <description>The default width and height ratio of the window.</description>
     </key>
     <key name="sizing-mode" enum="org.mate.Atril.SizingMode">
       <default>'fit-width'</default>
+      <summary>Page sizing mode</summary>
+      <description>The default page sizing mode: "fit-page", "fit-width", or "free".</description>
     </key>
     <key name="zoom" type="d">
       <default>1.</default>
+      <summary>Default zoom level</summary>
+      <description>The default zoom level when sizing mode is set to "free".</description>
     </key>
     <key name="inverted-colors" type="b">
       <default>false</default>
+      <summary>Invert document colors</summary>
+      <description>Whether to display documents with inverted colors.</description>
     </key>
     <key name="continuous" type="b">
       <default>true</default>
+      <summary>Continuous scrolling</summary>
+      <description>Whether to scroll pages continuously.</description>
     </key>
     <key name="dual-page" type="b">
       <default>false</default>
+      <summary>Dual page view</summary>
+      <description>Whether to show two pages side by side.</description>
     </key>
     <key name="dual-page-odd-left" type="b">
       <default>false</default>
+      <summary>Odd pages on the left in dual page mode</summary>
+      <description>Whether to place odd-numbered pages on the left side in dual page mode.</description>
     </key>
     <key name="fullscreen" type="b">
       <default>false</default>
+      <summary>Open in fullscreen mode</summary>
+      <description>Whether to open the document in fullscreen mode.</description>
     </key>
     <key name="sidebar-page" type="s">
       <default>'links'</default>
+      <summary>Default sidebar page</summary>
+      <description>The default sidebar page to show.</description>
     </key>
     <key name="sidebar-size" type="i">
       <default>132</default>
+      <summary>Side pane width</summary>
+      <description>The default width of the side pane in pixels.</description>
     </key>
   </schema>
 

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -1221,10 +1221,6 @@ ev_window_init_metadata_with_default_values (EvWindow *window)
 		ev_metadata_set_boolean (metadata, "dual-page-odd-left",
 					 g_settings_get_boolean (settings, "dual-page-odd-left"));
 	}
-	if (!ev_metadata_has_key (metadata, "inverted-colors")) {
-		ev_metadata_set_boolean (metadata, "inverted-colors",
-					 g_settings_get_boolean (settings, "inverted-colors"));
-	}
 	if (!ev_metadata_has_key (metadata, "sizing_mode")) {
 		EvSizingMode mode = g_settings_get_enum (settings, "sizing-mode");
 		GEnumValue *enum_value = g_enum_get_value (g_type_class_peek (EV_TYPE_SIZING_MODE), mode);
@@ -1335,6 +1331,10 @@ setup_model_from_metadata (EvWindow *window)
 	/* Inverted Colors */
 	if (ev_metadata_get_boolean (window->priv->metadata, "inverted-colors", &inverted_colors)) {
 		ev_document_model_set_inverted_colors (window->priv->model, inverted_colors);
+	} else {
+		ev_document_model_set_inverted_colors (window->priv->model,
+						       g_settings_get_boolean (window->priv->default_settings,
+									       "inverted-colors"));
 	}
 
 	/* Continuous */


### PR DESCRIPTION
Modify inverted colors preference to fall back to GSettings when no per-document metadata exists. This allows users to set inverted colors as the default preference, which will apply to all documents that don't have an explicit per-document preference.

Also added summary and description to all keys in the default schema so they are discoverable in dconf-editor.

Fixes #710 