### PR TITLE
Add allow-links-change-zoom setting

### DIFF
--- a/data/org.mate.Atril.gschema.xml
+++ b/data/org.mate.Atril.gschema.xml
@@ -34,6 +34,10 @@
       <default>true</default>
       <summary>Show a dialog to confirm that the user wants to activate the caret navigation.</summary>
     </key>
+    <key name="allow-links-change-zoom" type="b">
+      <default>false</default>
+      <summary>Allow links to change the zoom level.</summary>
+    </key>
     <child name="default" schema="org.mate.Atril.Default"/>
   </schema>
 

--- a/libview/ev-view-private.h
+++ b/libview/ev-view-private.h
@@ -174,6 +174,7 @@ struct _EvView {
 	EvPageLayout page_layout;
 	GtkWidget *loading_window;
 	guint loading_timeout;
+	gboolean allow_links_change_zoom;
 
 	/* Common for button press handling */
 	int pressed_button;

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -1764,6 +1764,24 @@ goto_xyz_dest (EvView *view, EvLinkDest *dest)
 }
 
 static void
+goto_y_dest (EvView *view, EvLinkDest *dest)
+{
+	gboolean change_top;
+	EvPoint doc_point;
+	gdouble top;
+	int page;
+
+	page = ev_link_dest_get_page (dest);
+	top = ev_link_dest_get_top (dest, &change_top);
+
+	doc_point.x = 0;
+	doc_point.y = change_top ? top : 0;
+	view->pending_point = doc_point;
+
+	ev_view_change_page (view, page);
+}
+
+static void
 goto_dest (EvView *view, EvLinkDest *dest)
 {
 	EvLinkDestType type;
@@ -1779,30 +1797,38 @@ goto_dest (EvView *view, EvLinkDest *dest)
 
 	type = ev_link_dest_get_dest_type (dest);
 
-	switch (type) {
-	        case EV_LINK_DEST_TYPE_PAGE:
-			ev_document_model_set_page (view->model, page);
-			break;
-	        case EV_LINK_DEST_TYPE_FIT:
-			goto_fit_dest (view, dest);
-			break;
-	        case EV_LINK_DEST_TYPE_FITH:
-			goto_fith_dest (view, dest);
-			break;
-	        case EV_LINK_DEST_TYPE_FITV:
-			goto_fitv_dest (view, dest);
-			break;
-	        case EV_LINK_DEST_TYPE_FITR:
-			goto_fitr_dest (view, dest);
-			break;
-	        case EV_LINK_DEST_TYPE_XYZ:
-			goto_xyz_dest (view, dest);
-			break;
-	        case EV_LINK_DEST_TYPE_PAGE_LABEL:
-			ev_document_model_set_page_by_label (view->model, ev_link_dest_get_page_label (dest));
-			break;
-	        default:
-			g_assert_not_reached ();
+	if (view->allow_links_change_zoom == FALSE &&
+	    view->sizing_mode == EV_SIZING_FIT_PAGE &&
+	    view->continuous == FALSE) {
+		ev_document_model_set_page (view->model, page);
+	} else if (view->allow_links_change_zoom == FALSE) {
+		goto_y_dest (view, dest);
+	} else {
+		switch (type) {
+		        case EV_LINK_DEST_TYPE_PAGE:
+				ev_document_model_set_page (view->model, page);
+				break;
+		        case EV_LINK_DEST_TYPE_FIT:
+				goto_fit_dest (view, dest);
+				break;
+		        case EV_LINK_DEST_TYPE_FITH:
+				goto_fith_dest (view, dest);
+				break;
+		        case EV_LINK_DEST_TYPE_FITV:
+				goto_fitv_dest (view, dest);
+				break;
+		        case EV_LINK_DEST_TYPE_FITR:
+				goto_fitr_dest (view, dest);
+				break;
+		        case EV_LINK_DEST_TYPE_XYZ:
+				goto_xyz_dest (view, dest);
+				break;
+		        case EV_LINK_DEST_TYPE_PAGE_LABEL:
+				ev_document_model_set_page_by_label (view->model, ev_link_dest_get_page_label (dest));
+				break;
+		        default:
+				g_assert_not_reached ();
+		}
 	}
 
 	if (current_page != view->current_page)
@@ -6525,6 +6551,7 @@ ev_view_init (EvView *view)
 #ifdef ENABLE_SYNCTEX
 	view->highlight_find_results = FALSE;
 #endif
+	view->allow_links_change_zoom = TRUE;
 	view->caret_enabled = FALSE;
 	view->cursor_page = 0;
 	view->zoom_center_x = -1;
@@ -8284,4 +8311,20 @@ ev_view_disconnect_handlers(EvView *view)
 	g_signal_handlers_disconnect_by_func(view->model,
 					     G_CALLBACK (ev_view_document_changed_cb),
 					     view);
+}
+
+void
+ev_view_set_allow_links_change_zoom (EvView *view, gboolean allowed)
+{
+	g_return_if_fail (EV_IS_VIEW (view));
+
+	view->allow_links_change_zoom = allowed;
+}
+
+gboolean
+ev_view_get_allow_links_change_zoom (EvView *view)
+{
+	g_return_val_if_fail (EV_IS_VIEW (view), FALSE);
+
+	return view->allow_links_change_zoom;
 }

--- a/libview/ev-view.h
+++ b/libview/ev-view.h
@@ -53,6 +53,10 @@ void            ev_view_reload              (EvView          *view);
 void            ev_view_set_page_cache_size (EvView          *view,
 					     gsize            cache_size);
 
+void            ev_view_set_allow_links_change_zoom (EvView  *view,
+                                                     gboolean allowed);
+gboolean        ev_view_get_allow_links_change_zoom (EvView  *view);
+
 /* Clipboard */
 void		ev_view_copy		  (EvView         *view);
 void            ev_view_copy_link_address (EvView         *view,

--- a/shell/ev-window.c
+++ b/shell/ev-window.c
@@ -265,6 +265,7 @@ struct _EvWindowPrivate {
 #define GS_OVERRIDE_RESTRICTIONS "override-restrictions"
 #define GS_PAGE_CACHE_SIZE       "page-cache-size"
 #define GS_AUTO_RELOAD           "auto-reload"
+#define GS_ALLOW_LINKS_CHANGE_ZOOM "allow-links-change-zoom"
 #define GS_LAST_DOCUMENT_DIRECTORY "document-directory"
 #define GS_LAST_PICTURES_DIRECTORY "pictures-directory"
 
@@ -1532,6 +1533,16 @@ page_cache_size_changed (GSettings *settings,
 }
 
 static void
+allow_links_change_zoom_changed (GSettings *settings,
+				 gchar     *key,
+				 EvWindow  *ev_window)
+{
+	gboolean allow_links_change_zoom = g_settings_get_boolean (settings, GS_ALLOW_LINKS_CHANGE_ZOOM);
+
+	ev_view_set_allow_links_change_zoom (EV_VIEW (ev_window->priv->view), allow_links_change_zoom);
+}
+
+static void
 ev_window_setup_default (EvWindow *ev_window)
 {
 	EvDocumentModel *model = ev_window->priv->model;
@@ -1672,6 +1683,10 @@ ev_window_ensure_settings (EvWindow *ev_window)
         g_signal_connect (priv->settings,
 			  "changed::"GS_PAGE_CACHE_SIZE,
 			  G_CALLBACK (page_cache_size_changed),
+			  ev_window);
+        g_signal_connect (priv->settings,
+			  "changed::"GS_ALLOW_LINKS_CHANGE_ZOOM,
+			  G_CALLBACK (allow_links_change_zoom_changed),
 			  ev_window);
 
         return priv->settings;
@@ -7925,6 +7940,7 @@ ev_window_init (EvWindow *ev_window)
 	GtkWidget *overlay;
 	GObject *mpkeys;
 	guint page_cache_mb;
+	gboolean allow_links_change_zoom;
 #ifdef ENABLE_DBUS
 	GDBusConnection *connection;
 	static gint window_id = 0;
@@ -8225,6 +8241,10 @@ ev_window_init (EvWindow *ev_window)
 					     GS_PAGE_CACHE_SIZE);
 	ev_view_set_page_cache_size (EV_VIEW (ev_window->priv->view),
 				     page_cache_mb * 1024 * 1024);
+	allow_links_change_zoom = g_settings_get_boolean (ev_window_ensure_settings (ev_window),
+							  GS_ALLOW_LINKS_CHANGE_ZOOM);
+	ev_view_set_allow_links_change_zoom (EV_VIEW (ev_window->priv->view),
+					     allow_links_change_zoom);
 	ev_view_set_model (EV_VIEW (ev_window->priv->view), ev_window->priv->model);
 
 	ev_window->priv->password_view = ev_password_view_new (GTK_WINDOW (ev_window));


### PR DESCRIPTION
When enabled links are not allowed to change the current zoom mode and level.

Fixes #712

Backported from https://gitlab.gnome.org/GNOME/evince/-/commit/5d8ef0fa