### PR TITLE
a11y: fix AT-SPI text selection across pages

### DIFF
--- a/libview/ev-page-accessible.c
+++ b/libview/ev-page-accessible.c
@@ -1025,9 +1025,9 @@ ev_page_accessible_set_selection (AtkText *text,
 	_ev_view_transform_doc_rect_to_view_rect (view, self->priv->page, areas + start_pos, &start_rect);
 	_ev_view_transform_doc_rect_to_view_rect (view, self->priv->page, areas + end_pos - 1, &end_rect);
 	start_point.x = start_rect.x;
-	start_point.y = start_rect.y;
+	start_point.y = start_rect.y + start_rect.height / 2;
 	end_point.x = end_rect.x + end_rect.width;
-	end_point.y = end_rect.y + end_rect.height;
+	end_point.y = end_rect.y + end_rect.height / 2;
 	_ev_view_set_selection (view, &start_point, &end_point);
 
 	return TRUE;

--- a/libview/ev-page-accessible.c
+++ b/libview/ev-page-accessible.c
@@ -997,12 +997,33 @@ ev_page_accessible_remove_selection (AtkText *text,
 	EvPageAccessible *self = EV_PAGE_ACCESSIBLE (text);
 	EvView *view = ev_page_accessible_get_view (self);
 
-	if (ev_view_get_has_selection (view)) {
-		_ev_view_clear_selection (view);
-		return TRUE;
-	}
+	return _ev_view_remove_page_selection (view, self->priv->page);
+}
 
-	return FALSE;
+static gboolean
+ev_page_accessible_get_selection_points (EvPageAccessible *self,
+					 EvView           *view,
+					 gint              start_pos,
+					 gint              end_pos,
+					 GdkPoint         *start_point,
+					 GdkPoint         *end_point)
+{
+	EvRectangle *areas = NULL;
+	guint n_areas = 0;
+	GdkRectangle start_rect, end_rect;
+
+	ev_page_cache_get_text_layout (view->page_cache, self->priv->page, &areas, &n_areas);
+	if (start_pos < 0 || end_pos >= n_areas)
+		return FALSE;
+
+	_ev_view_transform_doc_rect_to_view_rect (view, self->priv->page, areas + start_pos, &start_rect);
+	_ev_view_transform_doc_rect_to_view_rect (view, self->priv->page, areas + end_pos - 1, &end_rect);
+	start_point->x = start_rect.x;
+	start_point->y = start_rect.y + start_rect.height / 2;
+	end_point->x = end_rect.x + end_rect.width;
+	end_point->y = end_rect.y + end_rect.height / 2;
+
+	return TRUE;
 }
 
 static gboolean
@@ -1013,22 +1034,16 @@ ev_page_accessible_set_selection (AtkText *text,
 {
 	EvPageAccessible *self = EV_PAGE_ACCESSIBLE (text);
 	EvView *view = ev_page_accessible_get_view (self);
-	EvRectangle *areas = NULL;
-	guint n_areas = 0;
-	GdkRectangle start_rect, end_rect;
 	GdkPoint start_point, end_point;
 
-	ev_page_cache_get_text_layout (view->page_cache, self->priv->page, &areas, &n_areas);
-	if (start_pos < 0 || end_pos >= n_areas)
+	if (!ev_page_accessible_get_selection_points (self, view, start_pos, end_pos, &start_point, &end_point))
 		return FALSE;
 
-	_ev_view_transform_doc_rect_to_view_rect (view, self->priv->page, areas + start_pos, &start_rect);
-	_ev_view_transform_doc_rect_to_view_rect (view, self->priv->page, areas + end_pos - 1, &end_rect);
-	start_point.x = start_rect.x;
-	start_point.y = start_rect.y + start_rect.height / 2;
-	end_point.x = end_rect.x + end_rect.width;
-	end_point.y = end_rect.y + end_rect.height / 2;
-	_ev_view_set_selection (view, &start_point, &end_point);
+	/* AT-SPI clients call set_selection() to update a selection this page
+	 * already has (get_n_selections() == 1), and add_selection() to start
+	 * one where it currently has none. Both cases must only touch this
+	 * page's own selection, leaving selections on other pages alone. */
+	_ev_view_add_selection (view, &start_point, &end_point);
 
 	return TRUE;
 }
@@ -1038,8 +1053,16 @@ ev_page_accessible_add_selection (AtkText *text,
 				  gint     start_pos,
 				  gint     end_pos)
 {
-	return ev_page_accessible_set_selection (text, 0, start_pos, end_pos);
+	EvPageAccessible *self = EV_PAGE_ACCESSIBLE (text);
+	EvView *view = ev_page_accessible_get_view (self);
+	GdkPoint start_point, end_point;
 
+	if (!ev_page_accessible_get_selection_points (self, view, start_pos, end_pos, &start_point, &end_point))
+		return FALSE;
+
+	_ev_view_add_selection (view, &start_point, &end_point);
+
+	return TRUE;
 }
 
 static void

--- a/libview/ev-page-accessible.c
+++ b/libview/ev-page-accessible.c
@@ -1013,7 +1013,7 @@ ev_page_accessible_get_selection_points (EvPageAccessible *self,
 	GdkRectangle start_rect, end_rect;
 
 	ev_page_cache_get_text_layout (view->page_cache, self->priv->page, &areas, &n_areas);
-	if (start_pos < 0 || end_pos >= n_areas)
+	if (start_pos < 0 || end_pos > n_areas)
 		return FALSE;
 
 	_ev_view_transform_doc_rect_to_view_rect (view, self->priv->page, areas + start_pos, &start_rect);

--- a/libview/ev-page-accessible.c
+++ b/libview/ev-page-accessible.c
@@ -1063,6 +1063,7 @@ ev_page_accessible_text_iface_init (AtkTextIface *iface)
 	iface->get_selection = ev_page_accessible_get_selection;
 	iface->remove_selection = ev_page_accessible_remove_selection;
 	iface->add_selection = ev_page_accessible_add_selection;
+	iface->set_selection = ev_page_accessible_set_selection;
 	iface->get_run_attributes = ev_page_accessible_get_run_attributes;
 	iface->get_default_attributes = ev_page_accessible_get_default_attributes;
 	iface->get_character_extents = ev_page_accessible_get_character_extents;

--- a/libview/ev-view-accessible.c
+++ b/libview/ev-view-accessible.c
@@ -65,6 +65,10 @@ struct _EvViewAccessiblePrivate {
 	gint end_page;
 
 	GPtrArray *children;
+
+	/* Selection state as of the last "text-selection-changed" event,
+	 * for diffing which pages actually changed. */
+	GList *previous_selections;
 };
 
 G_DEFINE_TYPE_WITH_CODE (EvViewAccessible, ev_view_accessible, GTK_TYPE_CONTAINER_ACCESSIBLE,
@@ -110,6 +114,9 @@ ev_view_accessible_finalize (GObject *object)
 		g_source_remove (priv->action_idle_handler);
 	for (i = 0; i < LAST_ACTION; i++)
 		g_free (priv->action_descriptions [i]);
+
+	g_list_free_full (priv->previous_selections, g_free);
+	priv->previous_selections = NULL;
 
 	clear_children (EV_VIEW_ACCESSIBLE (object));
 
@@ -338,15 +345,46 @@ ev_view_accessible_cursor_moved (EvView *view,
 	g_signal_emit_by_name (page_accessible, "text-caret-moved", offset);
 }
 
+typedef struct {
+	gint        page;
+	EvRectangle rect;
+} SelectionSnapshot;
+
+static SelectionSnapshot *
+find_selection_snapshot (GList *snapshots,
+			 gint   page)
+{
+	GList *l;
+
+	for (l = snapshots; l != NULL; l = l->next) {
+		SelectionSnapshot *snapshot = l->data;
+
+		if (snapshot->page == page)
+			return snapshot;
+	}
+
+	return NULL;
+}
+
+static gboolean
+selection_rect_equal (EvRectangle *a,
+		      EvRectangle *b)
+{
+	return a->x1 == b->x1 && a->y1 == b->y1 &&
+	       a->x2 == b->x2 && a->y2 == b->y2;
+}
+
 static void
 ev_view_accessible_selection_changed (EvView *view,
                                       EvViewAccessible *view_accessible)
 {
+	EvViewAccessiblePrivate *priv = view_accessible->priv;
 	AtkObject *page_accessible;
 	GList *l;
+	GList *current = NULL;
 
-	if (view->selection_info.selections == NULL) {
-		page_accessible = g_ptr_array_index (view_accessible->priv->children,
+	if (view->selection_info.selections == NULL && priv->previous_selections == NULL) {
+		page_accessible = g_ptr_array_index (priv->children,
 						     get_relevant_page (view));
 		g_signal_emit_by_name (page_accessible, "text-selection-changed");
 		return;
@@ -358,11 +396,41 @@ ev_view_accessible_selection_changed (EvView *view,
 	 * currently considers "current" (e.g. via AT-SPI). */
 	for (l = view->selection_info.selections; l != NULL; l = l->next) {
 		EvViewSelection *selection = (EvViewSelection *) l->data;
+		SelectionSnapshot *snapshot = g_new (SelectionSnapshot, 1);
 
-		page_accessible = g_ptr_array_index (view_accessible->priv->children,
-						     selection->page);
+		snapshot->page = selection->page;
+		snapshot->rect = selection->rect;
+		current = g_list_prepend (current, snapshot);
+	}
+	current = g_list_reverse (current);
+
+	/* Only notify pages that their selection differs from last time.
+	 * A page untouched by this change shouldn't get random events. */
+	for (l = current; l != NULL; l = l->next) {
+		SelectionSnapshot *new_snapshot = l->data;
+		SelectionSnapshot *old_snapshot =
+			find_selection_snapshot (priv->previous_selections, new_snapshot->page);
+
+		if (old_snapshot != NULL && selection_rect_equal (&old_snapshot->rect, &new_snapshot->rect))
+			continue;
+
+		page_accessible = g_ptr_array_index (priv->children, new_snapshot->page);
 		g_signal_emit_by_name (page_accessible, "text-selection-changed");
 	}
+
+	/* A page that dropped out of the list lost its selection entirely. */
+	for (l = priv->previous_selections; l != NULL; l = l->next) {
+		SelectionSnapshot *old_snapshot = l->data;
+
+		if (find_selection_snapshot (current, old_snapshot->page) != NULL)
+			continue;
+
+		page_accessible = g_ptr_array_index (priv->children, old_snapshot->page);
+		g_signal_emit_by_name (page_accessible, "text-selection-changed");
+	}
+
+	g_list_free_full (priv->previous_selections, g_free);
+	priv->previous_selections = current;
 }
 
 static void

--- a/libview/ev-view-accessible.c
+++ b/libview/ev-view-accessible.c
@@ -343,10 +343,26 @@ ev_view_accessible_selection_changed (EvView *view,
                                       EvViewAccessible *view_accessible)
 {
 	AtkObject *page_accessible;
+	GList *l;
 
-	page_accessible = g_ptr_array_index (view_accessible->priv->children,
-					     get_relevant_page (view));
-	g_signal_emit_by_name (page_accessible, "text-selection-changed");
+	if (view->selection_info.selections == NULL) {
+		page_accessible = g_ptr_array_index (view_accessible->priv->children,
+						     get_relevant_page (view));
+		g_signal_emit_by_name (page_accessible, "text-selection-changed");
+		return;
+	}
+
+	/* Notify every page that actually has a selection, rather than
+	 * guessing based on the current/cursor page, since the selection
+	 * may have been made on a page other than the one the view
+	 * currently considers "current" (e.g. via AT-SPI). */
+	for (l = view->selection_info.selections; l != NULL; l = l->next) {
+		EvViewSelection *selection = (EvViewSelection *) l->data;
+
+		page_accessible = g_ptr_array_index (view_accessible->priv->children,
+						     selection->page);
+		g_signal_emit_by_name (page_accessible, "text-selection-changed");
+	}
 }
 
 static void

--- a/libview/ev-view-private.h
+++ b/libview/ev-view-private.h
@@ -294,9 +294,11 @@ gint _ev_view_get_caret_cursor_offset_at_doc_point (EvView *view,
                                                     gdouble doc_x,
                                                     gdouble doc_y);
 void _ev_view_clear_selection (EvView   *view);
-void _ev_view_set_selection   (EvView   *view,
+void _ev_view_add_selection   (EvView   *view,
                                GdkPoint *start_point,
                                GdkPoint *end_point);
+gboolean _ev_view_remove_page_selection (EvView *view,
+                                         gint    page);
 void _ev_view_set_focused_element (EvView *view,
                                    EvMapping *element_mapping,
                                    gint page);

--- a/libview/ev-view.c
+++ b/libview/ev-view.c
@@ -8006,6 +8006,57 @@ selection_free (EvViewSelection *selection)
 	g_slice_free (EvViewSelection, selection);
 }
 
+static EvViewSelection *
+selection_dup (EvViewSelection *selection)
+{
+	EvViewSelection *new_selection = g_slice_new0 (EvViewSelection);
+
+	new_selection->page = selection->page;
+	new_selection->rect = selection->rect;
+	new_selection->style = selection->style;
+
+	return new_selection;
+}
+
+static gint
+selection_compare_pages (gconstpointer a,
+			 gconstpointer b)
+{
+	const EvViewSelection *sel_a = a;
+	const EvViewSelection *sel_b = b;
+
+	return sel_a->page - sel_b->page;
+}
+
+/* Duplicates every selection whose page falls outside [first, last],
+ * dropping (and optionally flagging) the ones inside that range. */
+static GList *
+dup_selections_outside_range (GList    *selections,
+			      gint      first,
+			      gint      last,
+			      gboolean *out_had_match)
+{
+	GList *l;
+	GList *result = NULL;
+
+	if (out_had_match)
+		*out_had_match = FALSE;
+
+	for (l = selections; l != NULL; l = l->next) {
+		EvViewSelection *selection = l->data;
+
+		if (selection->page >= first && selection->page <= last) {
+			if (out_had_match)
+				*out_had_match = TRUE;
+			continue;
+		}
+
+		result = g_list_prepend (result, selection_dup (selection));
+	}
+
+	return result;
+}
+
 static void
 clear_selection (EvView *view)
 {
@@ -8054,12 +8105,60 @@ _ev_view_clear_selection (EvView *view)
 	clear_selection (view);
 }
 
+/* Adds (or updates) the selection on whichever page(s) start_point/end_point
+ * fall on, keeping any existing selection on other pages instead of
+ * discarding it. Used for both AT-SPI set_selection (updating a page's own
+ * existing selection) and add_selection (starting a new one), since both
+ * must only affect the page(s) actually being selected. */
 void
-_ev_view_set_selection (EvView   *view,
+_ev_view_add_selection (EvView   *view,
                         GdkPoint *start_point,
                         GdkPoint *end_point)
 {
-	compute_selections (view, EV_SELECTION_STYLE_GLYPH, start_point, end_point);
+	GList *new_range, *l;
+	GList *merged;
+	gint new_first = G_MAXINT;
+	gint new_last = G_MININT;
+
+	new_range = compute_new_selection (view, EV_SELECTION_STYLE_GLYPH, start_point, end_point);
+	if (new_range == NULL)
+		return;
+
+	for (l = new_range; l != NULL; l = l->next) {
+		EvViewSelection *selection = l->data;
+
+		new_first = MIN (new_first, selection->page);
+		new_last = MAX (new_last, selection->page);
+	}
+
+	merged = dup_selections_outside_range (view->selection_info.selections,
+					       new_first, new_last, NULL);
+	merged = g_list_concat (merged, new_range);
+	merged = g_list_sort (merged, selection_compare_pages);
+
+	merge_selection_region (view, merged);
+}
+
+/* Removes the selection on a single page, leaving any selection on other
+ * pages untouched. Returns FALSE if the given page had no selection. */
+gboolean
+_ev_view_remove_page_selection (EvView *view,
+                                gint    page)
+{
+	GList *new_list;
+	gboolean had_selection;
+
+	new_list = dup_selections_outside_range (view->selection_info.selections,
+						 page, page, &had_selection);
+
+	if (!had_selection) {
+		g_list_free_full (new_list, (GDestroyNotify) selection_free);
+		return FALSE;
+	}
+
+	merge_selection_region (view, g_list_reverse (new_list));
+
+	return TRUE;
 }
 
 static char *


### PR DESCRIPTION
Fixes a bunch of AT-SPI text-selection bugs reported against Atril's accessibility layer, all blocking Orca's caret-navigation work at https://gitlab.gnome.org/GNOME/orca/-/work_items/744

Fixes #718
Fixes #719
Fixes #720
Fixes #721
Fixes #722
Fixes #723
